### PR TITLE
Add authenticated multi-agent ingestion and query orchestration

### DIFF
--- a/worker/cli.py
+++ b/worker/cli.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
+from typing import List, Optional
 
 import typer
 
+from tigerchain_app.agents import QueryContext
 from tigerchain_app.context import build_context
-from tigerchain_app.rag.chain import format_sources
 from tigerchain_app.utils.logging import configure_logging, get_logger
 
 app = typer.Typer(help="TigerChain CLI utilities")
@@ -14,7 +16,12 @@ logger = get_logger(__name__)
 
 
 @app.command()
-def ingest(path: Path = typer.Argument(..., exists=True, help="Path to a document file or directory")) -> None:
+def ingest(
+    path: Path = typer.Argument(..., exists=True, help="Path to a document file or directory"),
+    owner: Optional[str] = typer.Option(None, "--owner", help="Optional owner identifier to scope the document"),
+    category: List[str] = typer.Option([], "--category", help="Categories associated with the document"),
+    agent: Optional[str] = typer.Option(None, "--agent", help="Agent/model alias to tag the ingestion with"),
+) -> None:
     """Parse, embed and upsert documents into TigerGraph."""
 
     configure_logging()
@@ -23,26 +30,49 @@ def ingest(path: Path = typer.Argument(..., exists=True, help="Path to a documen
 
     if path.is_dir():
         logger.info("Ingesting directory %s", path)
-        pipeline.ingest_directory(path)
+        result = pipeline.ingest_directory(path, owner_id=owner, categories=category, model_alias=agent)
     else:
         logger.info("Ingesting file %s", path)
-        pipeline.ingest_files([path])
+        result = pipeline.ingest_files([path], owner_id=owner, categories=category, model_alias=agent)
+    typer.echo(f"Ingested {len(result.chunks)} chunks from {len(result.documents)} document(s)")
 
 
 @app.command()
-def query(question: str = typer.Argument(..., help="Natural language question to ask")) -> None:
+def query(
+    question: str = typer.Argument(..., help="Natural language question to ask"),
+    agent: Optional[str] = typer.Option(None, "--agent", help="Agent/model alias to execute the query"),
+    mode: str = typer.Option("sequential", "--mode", help="Execution mode: sequential or parallel"),
+    owner: Optional[str] = typer.Option(None, "--owner", help="Optional owner identifier to filter results"),
+    category: List[str] = typer.Option([], "--category", help="Filter results by categories"),
+) -> None:
     """Execute retrieval-augmented generation over TigerGraph content."""
 
     configure_logging()
     context = build_context(force=True)
-    qa_chain = context.qa_chain
-
-    result = qa_chain.invoke({"query": question})
+    orchestrator = context.agent_orchestrator
+    agent_names = [agent] if agent else None
+    results = asyncio.run(
+        orchestrator.run_query(
+            question=question,
+            agent_names=agent_names,
+            query_context=QueryContext(owner_id=owner, categories=category, model_alias=agent),
+            mode=mode,
+        )
+    )
     output = {
         "question": question,
-        "answer": result.get("result"),
-        "sources": format_sources(result.get("source_documents", [])),
+        "mode": mode,
+        "results": [
+            {
+                "agent": res.agent,
+                "answer": res.answer,
+                "sources": res.sources,
+            }
+            for res in results
+        ],
     }
+    if output["results"]:
+        output["answer"] = output["results"][0]["answer"]
     typer.echo(json.dumps(output, indent=2))
 
 

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -17,6 +17,7 @@ PyMuPDF==1.24.9
 # API
 fastapi==0.112.2
 uvicorn[standard]==0.30.6
-
-# Optional: if you plan to accept file uploads via API in the future
-# python-multipart==0.0.9
+python-multipart==0.0.9
+sqlmodel==0.0.21
+passlib[bcrypt]==1.7.4
+python-jose==3.3.0

--- a/worker/server.py
+++ b/worker/server.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
-from typing import List
+from typing import List, Literal, Optional
 
-from fastapi import Depends, FastAPI, File, UploadFile
+from fastapi import Body, Depends, FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from sqlmodel import Session, select
 
+from tigerchain_app.agents import QueryContext
+from tigerchain_app.auth.database import get_session
+from tigerchain_app.auth.models import DocumentUpload, User
+from tigerchain_app.auth.router import router as auth_router
+from tigerchain_app.auth.schemas import DocumentRecord
+from tigerchain_app.auth.security import get_current_active_user
+from tigerchain_app.auth.service import DocumentService
 from tigerchain_app.context import build_context
-from tigerchain_app.rag.chain import format_sources
 from tigerchain_app.utils.logging import configure_logging, get_logger
 
 configure_logging()
@@ -23,6 +32,45 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+app.include_router(auth_router, prefix="/auth", tags=["auth"])
+
+
+class QueryRequest(BaseModel):
+    question: str
+    agent: Optional[str] = None
+    agents: Optional[List[str]] = None
+    mode: Literal["sequential", "parallel"] = "sequential"
+    categories: Optional[List[str]] = None
+
+
+class IngestedDocumentResponse(BaseModel):
+    doc_id: str
+    filename: str
+    categories: List[str]
+    model_alias: Optional[str]
+    object_uri: Optional[str]
+    http_url: Optional[str]
+    metadata: Optional[dict] = None
+
+
+class IngestResponse(BaseModel):
+    ingested_chunks: int
+    documents: List[IngestedDocumentResponse]
+    agent: str
+
+
+class AgentResult(BaseModel):
+    agent: str
+    answer: Optional[str]
+    sources: List[dict]
+
+
+class QueryResponse(BaseModel):
+    question: str
+    mode: str
+    answer: Optional[str]
+    results: List[AgentResult]
+
 
 @app.on_event("startup")
 async def on_startup() -> None:
@@ -34,15 +82,28 @@ def get_context():
     return build_context()
 
 
-@app.post("/ingest")
+@app.post("/ingest", response_model=IngestResponse)
 async def ingest_documents(
     files: List[UploadFile] = File(..., description="Documents to ingest"),
+    category: Optional[str] = Form(default=None, description="Primary category for the upload"),
+    categories: Optional[List[str]] = Form(default=None, description="Additional categories"),
+    model_alias: Optional[str] = Form(default=None, description="Agent/model alias to tag the document"),
+    metadata: Optional[str] = Form(default=None, description="Optional JSON metadata to persist with the upload"),
     context=Depends(get_context),
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_active_user),
 ):
     pipeline = context.pipeline
     storage_dir = context.settings.storage_base_path
     storage_dir.mkdir(parents=True, exist_ok=True)
     paths: List[Path] = []
+
+    extra_metadata: dict | None = None
+    if metadata:
+        try:
+            extra_metadata = json.loads(metadata)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(status_code=400, detail="metadata must be valid JSON") from exc
 
     for upload in files:
         temp_path = storage_dir / upload.filename
@@ -51,26 +112,126 @@ async def ingest_documents(
         paths.append(temp_path)
         logger.info("Uploaded %s (%s bytes)", upload.filename, temp_path.stat().st_size)
 
-    rows = pipeline.ingest_files(paths)
+    orchestrator = context.agent_orchestrator
+    available_agents = set(orchestrator.available_agents())
+    preferred_agent = model_alias or current_user.preferred_agent or context.settings.default_agent
+    if preferred_agent not in available_agents:
+        raise HTTPException(status_code=400, detail=f"Unknown agent '{preferred_agent}'")
+
+    category_values = set(current_user.categories or [])
+    if category:
+        category_values.add(category)
+    if categories:
+        category_values.update({value for value in categories if value})
+
+    ingestion_result = pipeline.ingest_files(
+        paths,
+        owner_id=str(current_user.id),
+        categories=category_values,
+        model_alias=preferred_agent,
+        extra_metadata=extra_metadata,
+    )
+
+    document_service = DocumentService(session)
+    response_docs: List[IngestedDocumentResponse] = []
+    for summary in ingestion_result.documents:
+        record = document_service.record_upload(
+            user_id=current_user.id,
+            doc_id=summary.doc_id,
+            filename=summary.source_path.name,
+            categories=summary.categories,
+            model_alias=summary.model_alias,
+            object_uri=summary.uri,
+            http_url=summary.http_url,
+            metadata=summary.metadata,
+        )
+        response_docs.append(
+            IngestedDocumentResponse(
+                doc_id=record.doc_id,
+                filename=record.filename,
+                categories=record.categories,
+                model_alias=record.model_alias,
+                object_uri=record.object_uri,
+                http_url=record.http_url,
+                metadata=record.metadata,
+            )
+        )
+
     for path in paths:
         try:
             path.unlink(missing_ok=True)
         except Exception:
             logger.warning("Failed to remove temporary file %s", path)
-    return {"ingested_chunks": len(rows)}
+    return IngestResponse(ingested_chunks=len(ingestion_result.chunks), documents=response_docs, agent=preferred_agent)
 
 
-@app.post("/query")
+@app.post("/query", response_model=QueryResponse)
 async def query_rag(
-    question: str,
+    request: QueryRequest = Body(..., description="Query payload"),
     context=Depends(get_context),
+    current_user: User = Depends(get_current_active_user),
 ):
-    result = context.qa_chain.invoke({"query": question})
-    return {
-        "question": question,
-        "answer": result.get("result"),
-        "sources": format_sources(result.get("source_documents", [])),
-    }
+    orchestrator = context.agent_orchestrator
+    agent_names = request.agents or ([request.agent] if request.agent else None)
+    if agent_names:
+        available_agents = set(orchestrator.available_agents())
+        invalid = [name for name in agent_names if name not in available_agents]
+        if invalid:
+            raise HTTPException(status_code=400, detail=f"Unknown agent(s): {', '.join(invalid)}")
+    else:
+        default_agent = current_user.preferred_agent or context.settings.default_agent
+        agent_names = [default_agent]
+
+    categories = request.categories or current_user.categories
+    query_context = QueryContext(
+        owner_id=str(current_user.id),
+        categories=categories,
+        model_alias=agent_names[0],
+    )
+    results = await orchestrator.run_query(
+        question=request.question,
+        agent_names=agent_names,
+        query_context=query_context,
+        mode=request.mode,
+    )
+    formatted_results = [
+        AgentResult(agent=result.agent, answer=result.answer, sources=result.sources)
+        for result in results
+    ]
+    answer = formatted_results[0].answer if formatted_results else None
+    return QueryResponse(question=request.question, mode=request.mode, answer=answer, results=formatted_results)
+
+
+@app.get("/agents")
+async def list_agents(context=Depends(get_context)):
+    settings = context.settings
+    agents = []
+    for name in context.agent_orchestrator.available_agents():
+        config = settings.model_registry.get(name, {})
+        agents.append(
+            {
+                "name": name,
+                "provider": config.get("provider"),
+                "model": config.get("model"),
+                "temperature": config.get("temperature"),
+            }
+        )
+    return {"agents": agents}
+
+
+@app.get("/documents", response_model=List[DocumentRecord])
+async def list_user_documents(
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_active_user),
+):
+    statement = (
+        select(DocumentUpload)
+        .where(DocumentUpload.user_id == current_user.id)
+        .order_by(DocumentUpload.created_at.desc())
+        .limit(50)
+    )
+    records = session.exec(statement).all()
+    return [DocumentRecord.model_validate(record) for record in records]
 
 
 @app.get("/healthz")

--- a/worker/tigerchain_app/agents/__init__.py
+++ b/worker/tigerchain_app/agents/__init__.py
@@ -1,0 +1,9 @@
+"""Multi-agent orchestration utilities."""
+
+from .orchestrator import AgentOrchestrator, AgentQueryResult, QueryContext
+
+__all__ = [
+    "AgentOrchestrator",
+    "AgentQueryResult",
+    "QueryContext",
+]

--- a/worker/tigerchain_app/agents/orchestrator.py
+++ b/worker/tigerchain_app/agents/orchestrator.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from langchain.chains import RetrievalQA
+from langchain_core.embeddings import Embeddings
+
+from ..config import Settings
+from ..rag.chain import build_qa_chain, format_sources
+from ..rag.llms import create_llm_from_config
+from ..rag.retriever import RetrievalContext, TigerGraphVectorRetriever
+from ..utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class QueryContext:
+    owner_id: Optional[str] = None
+    categories: Optional[Iterable[str]] = None
+    model_alias: Optional[str] = None
+
+
+@dataclass
+class AgentQueryResult:
+    agent: str
+    answer: Optional[str]
+    sources: List[Dict[str, Optional[str]]]
+
+
+class RagAgent:
+    def __init__(
+        self,
+        name: str,
+        config: Dict[str, object],
+        settings: Settings,
+        embeddings: Embeddings,
+        tigergraph_client: "TigerGraphClient",
+    ) -> None:
+        self.name = name
+        self.config = config
+        self.settings = settings
+        self.embeddings = embeddings
+        self.tigergraph_client = tigergraph_client
+        self._retriever: TigerGraphVectorRetriever | None = None
+        self._chain: RetrievalQA | None = None
+
+    def _ensure_components(self) -> tuple[TigerGraphVectorRetriever, RetrievalQA]:
+        if self._retriever is None:
+            self._retriever = TigerGraphVectorRetriever(self.settings, self.embeddings, self.tigergraph_client)
+        if self._chain is None:
+            llm = create_llm_from_config(self.settings, self.config)
+            self._chain = build_qa_chain(self.settings, self._retriever, llm)
+        return self._retriever, self._chain
+
+    async def arun(self, query: str, context: QueryContext) -> AgentQueryResult:
+        retriever, chain = self._ensure_components()
+        categories = set(context.categories or []) or None
+        retrieval_context = RetrievalContext(
+            owner_id=context.owner_id,
+            categories=categories,
+            model_alias=context.model_alias or self.name,
+        )
+        logger.debug("Agent %s executing query with filters: %s", self.name, retrieval_context)
+        with retriever.use_context(retrieval_context):
+            result = await chain.ainvoke({"query": query})
+        answer = result.get("result") if isinstance(result, dict) else None
+        sources = format_sources(result.get("source_documents", [])) if isinstance(result, dict) else []
+        return AgentQueryResult(agent=self.name, answer=answer, sources=sources)
+
+
+class AgentOrchestrator:
+    """Coordinates multiple local or remote RAG agents."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        embeddings: Embeddings,
+        tigergraph_client: "TigerGraphClient",
+    ) -> None:
+        self.settings = settings
+        self.embeddings = embeddings
+        self.tigergraph_client = tigergraph_client
+        self._agents: Dict[str, RagAgent] = {}
+
+    # ------------------------------------------------------------------
+    # Agent management
+    # ------------------------------------------------------------------
+    def available_agents(self) -> List[str]:
+        return sorted(self.settings.model_registry.keys())
+
+    def _get_agent(self, name: str) -> RagAgent:
+        if name not in self.settings.model_registry:
+            raise ValueError(f"Unknown agent '{name}'")
+        if name not in self._agents:
+            config = self.settings.model_registry[name]
+            self._agents[name] = RagAgent(name, config, self.settings, self.embeddings, self.tigergraph_client)
+        return self._agents[name]
+
+    # ------------------------------------------------------------------
+    # Query execution
+    # ------------------------------------------------------------------
+    async def run_query(
+        self,
+        question: str,
+        agent_names: Optional[Sequence[str]] = None,
+        query_context: Optional[QueryContext] = None,
+        mode: str = "sequential",
+    ) -> List[AgentQueryResult]:
+        if not agent_names:
+            agent_names = [self.settings.default_agent]
+        query_context = query_context or QueryContext()
+
+        agents = [self._get_agent(name) for name in agent_names]
+        if mode == "parallel" and len(agents) > 1:
+            tasks = [agent.arun(question, query_context) for agent in agents]
+            results = await asyncio.gather(*tasks)
+        else:
+            results = []
+            for agent in agents:
+                results.append(await agent.arun(question, query_context))
+        return results
+
+
+class TigerGraphClient:  # pragma: no cover - circular reference helper
+    ...

--- a/worker/tigerchain_app/auth/__init__.py
+++ b/worker/tigerchain_app/auth/__init__.py
@@ -1,0 +1,10 @@
+"""Authentication and user management utilities for TigerChain."""
+
+from . import models, router, security, service  # noqa: F401
+
+__all__ = [
+    "models",
+    "router",
+    "security",
+    "service",
+]

--- a/worker/tigerchain_app/auth/database.py
+++ b/worker/tigerchain_app/auth/database.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from fastapi import Depends
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, SQLModel, create_engine
+
+from ..config import Settings, get_settings
+
+_engine: Engine | None = None
+
+
+def get_engine(settings: Settings) -> Engine:
+    global _engine
+    if _engine is not None:
+        return _engine
+    connect_args = {"check_same_thread": False} if settings.database_url.startswith("sqlite") else {}
+    _engine = create_engine(settings.database_url, echo=False, connect_args=connect_args)
+    return _engine
+
+
+def init_db(settings: Settings) -> None:
+    engine = get_engine(settings)
+    SQLModel.metadata.create_all(engine)
+
+
+@contextmanager
+def session_scope(settings: Settings) -> Iterator[Session]:
+    engine = get_engine(settings)
+    with Session(engine) as session:
+        yield session
+
+
+def get_session(settings: Settings = Depends(get_settings)) -> Iterator[Session]:
+    engine = get_engine(settings)
+    with Session(engine) as session:
+        yield session

--- a/worker/tigerchain_app/auth/models.py
+++ b/worker/tigerchain_app/auth/models.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from sqlalchemy import Column
+from sqlalchemy.types import JSON
+from sqlmodel import Field, SQLModel
+
+
+class User(SQLModel, table=True):
+    """Persistent user representation used for authentication and onboarding."""
+
+    __tablename__ = "users"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    email: str = Field(index=True, unique=True)
+    full_name: Optional[str] = Field(default=None)
+    hashed_password: str
+    is_active: bool = Field(default=True)
+    onboarding_complete: bool = Field(default=False)
+    preferred_agent: Optional[str] = Field(default=None, index=True)
+    categories: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class DocumentUpload(SQLModel, table=True):
+    """Tracks document ingestion activity for auditing and filtering."""
+
+    __tablename__ = "document_uploads"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: Optional[int] = Field(default=None, foreign_key="users.id", index=True)
+    doc_id: str = Field(index=True)
+    filename: str
+    categories: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    model_alias: Optional[str] = Field(default=None, index=True)
+    object_uri: Optional[str] = Field(default=None)
+    http_url: Optional[str] = Field(default=None)
+    metadata: dict = Field(default_factory=dict, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)

--- a/worker/tigerchain_app/auth/router.py
+++ b/worker/tigerchain_app/auth/router.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlmodel import Session
+
+from ..config import Settings, get_settings
+from .database import get_session
+from .models import User
+from .schemas import OnboardingRequest, Token, UserCreate, UserRead
+from .security import create_access_token, get_current_active_user
+from .service import UserService
+
+
+router = APIRouter()
+
+
+@router.post("/register", response_model=UserRead)
+def register_user(
+    payload: UserCreate,
+    session: Session = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> UserRead:
+    service = UserService(session, settings)
+    user = service.create_user(payload)
+    return UserRead.model_validate(user)
+
+
+@router.post("/token", response_model=Token)
+def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    session: Session = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> Token:
+    service = UserService(session, settings)
+    user = service.authenticate_user(form_data.username, form_data.password)
+    token = create_access_token(subject=str(user.id), settings=settings)
+    return Token(access_token=token)
+
+
+@router.get("/me", response_model=UserRead)
+def read_current_user(current_user: User = Depends(get_current_active_user)) -> UserRead:
+    return UserRead.model_validate(current_user)
+
+
+@router.post("/onboarding", response_model=UserRead)
+def complete_onboarding(
+    payload: OnboardingRequest,
+    session: Session = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+    current_user: User = Depends(get_current_active_user),
+) -> UserRead:
+    service = UserService(session, settings)
+    user = service.update_user_preferences(current_user, payload)
+    return UserRead.model_validate(user)

--- a/worker/tigerchain_app/auth/schemas.py
+++ b/worker/tigerchain_app/auth/schemas.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8, max_length=128)
+    full_name: Optional[str] = None
+    preferred_agent: Optional[str] = None
+    categories: Optional[List[str]] = None
+
+
+class UserRead(BaseModel):
+    id: int
+    email: EmailStr
+    full_name: Optional[str]
+    is_active: bool
+    onboarding_complete: bool
+    preferred_agent: Optional[str]
+    categories: List[str]
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class TokenData(BaseModel):
+    sub: Optional[str] = None
+
+
+class OnboardingRequest(BaseModel):
+    full_name: Optional[str] = None
+    preferred_agent: Optional[str] = None
+    categories: Optional[List[str]] = None
+
+
+class DocumentRecord(BaseModel):
+    doc_id: str
+    filename: str
+    categories: List[str]
+    model_alias: Optional[str]
+    object_uri: Optional[str]
+    http_url: Optional[str]
+    metadata: Optional[dict]
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/worker/tigerchain_app/auth/security.py
+++ b/worker/tigerchain_app/auth/security.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlmodel import Session
+
+from ..config import Settings, get_settings
+from .database import get_session
+from .models import User
+from .schemas import TokenData
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(*, subject: str, settings: Settings, expires_delta: Optional[timedelta] = None) -> str:
+    expire = datetime.now(timezone.utc) + (
+        expires_delta or timedelta(minutes=settings.access_token_expire_minutes)
+    )
+    to_encode = {"sub": subject, "exp": expire}
+    encoded_jwt = jwt.encode(to_encode, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+    return encoded_jwt
+
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    session: Session = Depends(get_session),
+    settings: Settings = Depends(get_settings),
+) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+        subject: str | None = payload.get("sub")
+        if subject is None:
+            raise credentials_exception
+        token_data = TokenData(sub=subject)
+    except JWTError as exc:  # pragma: no cover - defensive path
+        raise credentials_exception from exc
+
+    try:
+        user_id = int(token_data.sub) if token_data.sub is not None else None
+    except (TypeError, ValueError) as exc:
+        raise credentials_exception from exc
+
+    user = session.get(User, user_id) if user_id is not None else None
+    if user is None:
+        raise credentials_exception
+    return user
+
+
+def get_current_active_user(current_user: User = Depends(get_current_user)) -> User:
+    if not current_user.is_active:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Inactive user")
+    return current_user

--- a/worker/tigerchain_app/auth/service.py
+++ b/worker/tigerchain_app/auth/service.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, List, Optional
+
+from fastapi import HTTPException, status
+from sqlmodel import Session, select
+
+from ..config import Settings
+from ..utils.logging import get_logger
+from .models import DocumentUpload, User
+from .schemas import OnboardingRequest, UserCreate
+from .security import get_password_hash, verify_password
+
+logger = get_logger(__name__)
+
+
+class UserService:
+    def __init__(self, session: Session, settings: Settings) -> None:
+        self.session = session
+        self.settings = settings
+
+    # ------------------------------------------------------------------
+    # User management
+    # ------------------------------------------------------------------
+    def _validate_agent(self, agent: Optional[str]) -> Optional[str]:
+        if agent is None:
+            return None
+        if agent not in self.settings.model_registry:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Unknown agent '{agent}'")
+        return agent
+
+    def _normalise_categories(self, categories: Optional[Iterable[str]]) -> List[str]:
+        if not categories:
+            return []
+        unique = {c.strip() for c in categories if c and c.strip()}
+        return sorted(unique)
+
+    def create_user(self, payload: UserCreate) -> User:
+        existing = self.session.exec(select(User).where(User.email == payload.email.lower())).first()
+        if existing:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered")
+
+        preferred_agent = self._validate_agent(payload.preferred_agent) or self.settings.default_agent
+        self._validate_agent(preferred_agent)
+
+        user = User(
+            email=payload.email.lower(),
+            full_name=payload.full_name,
+            hashed_password=get_password_hash(payload.password),
+            preferred_agent=preferred_agent,
+            categories=self._normalise_categories(payload.categories),
+            onboarding_complete=False,
+        )
+        self.session.add(user)
+        self.session.commit()
+        self.session.refresh(user)
+        logger.info("Created user %s", user.email)
+        return user
+
+    def authenticate_user(self, email: str, password: str) -> User:
+        statement = select(User).where(User.email == email.lower())
+        user = self.session.exec(statement).first()
+        if not user or not verify_password(password, user.hashed_password):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect email or password")
+        if not user.is_active:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Inactive user")
+        return user
+
+    def update_user_preferences(self, user: User, payload: OnboardingRequest) -> User:
+        updated = False
+        if payload.full_name is not None:
+            user.full_name = payload.full_name
+            updated = True
+        if payload.preferred_agent is not None:
+            user.preferred_agent = self._validate_agent(payload.preferred_agent) or user.preferred_agent
+            updated = True
+        if payload.categories is not None:
+            user.categories = self._normalise_categories(payload.categories)
+            updated = True
+        if updated:
+            user.updated_at = datetime.utcnow()
+        user.onboarding_complete = True
+        self.session.add(user)
+        self.session.commit()
+        self.session.refresh(user)
+        return user
+
+
+class DocumentService:
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def record_upload(
+        self,
+        *,
+        user_id: Optional[int],
+        doc_id: str,
+        filename: str,
+        categories: Iterable[str],
+        model_alias: Optional[str],
+        object_uri: Optional[str],
+        http_url: Optional[str],
+        metadata: Optional[dict] = None,
+    ) -> DocumentUpload:
+        record = DocumentUpload(
+            user_id=user_id,
+            doc_id=doc_id,
+            filename=filename,
+            categories=sorted({c.strip() for c in categories if c}),
+            model_alias=model_alias,
+            object_uri=object_uri,
+            http_url=http_url,
+            metadata=metadata or {},
+        )
+        self.session.add(record)
+        self.session.commit()
+        self.session.refresh(record)
+        return record

--- a/worker/tigerchain_app/ingestion/chunking.py
+++ b/worker/tigerchain_app/ingestion/chunking.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Tuple
+
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_core.documents import Document
+
+from ..config import Settings
+
+
+class AdaptiveChunker:
+    """Adaptive text splitter that tunes chunk parameters per document type."""
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self._splitters: Dict[Tuple[int, int], RecursiveCharacterTextSplitter] = {}
+
+    def split_documents(self, documents: list[Document]) -> list[Document]:
+        chunks: list[Document] = []
+        for document in documents:
+            chunk_size, chunk_overlap = self._resolve_params(document)
+            splitter = self._get_splitter(chunk_size, chunk_overlap)
+            chunks.extend(splitter.split_documents([document]))
+        return chunks
+
+    def _get_splitter(self, chunk_size: int, chunk_overlap: int) -> RecursiveCharacterTextSplitter:
+        key = (chunk_size, chunk_overlap)
+        if key not in self._splitters:
+            self._splitters[key] = RecursiveCharacterTextSplitter(
+                chunk_size=chunk_size,
+                chunk_overlap=chunk_overlap,
+            )
+        return self._splitters[key]
+
+    def _resolve_params(self, document: Document) -> tuple[int, int]:
+        chunk_size = self.settings.chunk_size
+        chunk_overlap = self.settings.chunk_overlap
+
+        source = document.metadata.get("source")
+        suffix = Path(source).suffix.lower() if isinstance(source, str) else ""
+        content_length = len(document.page_content or "")
+
+        if suffix == ".md":
+            chunk_size = max(400, chunk_size // 2)
+            chunk_overlap = min(chunk_overlap, chunk_size // 4)
+        elif suffix == ".pdf" and content_length > 4000:
+            chunk_size = min(chunk_size + 200, 1200)
+        elif suffix == ".txt" and content_length < chunk_size:
+            chunk_size = max(256, max(content_length // 2, 128))
+            chunk_overlap = min(chunk_overlap, chunk_size // 4)
+
+        return chunk_size, chunk_overlap

--- a/worker/tigerchain_app/rag/llms.py
+++ b/worker/tigerchain_app/rag/llms.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, Mapping
+
 from langchain_core.language_models import BaseLanguageModel
 from langchain_community.llms import Ollama, VLLMOpenAI
 from langchain_openai import ChatOpenAI
@@ -11,28 +13,44 @@ logger = get_logger(__name__)
 
 
 def create_llm(settings: Settings) -> BaseLanguageModel:
-    provider = settings.llm_provider.lower()
-    logger.info("Using %s provider with model %s", provider, settings.llm_model)
+    config = {
+        "provider": settings.llm_provider,
+        "model": settings.llm_model,
+        "temperature": settings.llm_temperature,
+        "api_key": settings.openai_api_key,
+        "api_base": settings.openai_api_base,
+        "base_url": settings.ollama_base_url,
+        "vllm_api_base": settings.vllm_api_base,
+    }
+    return create_llm_from_config(settings, config)
+
+
+def create_llm_from_config(settings: Settings, config: Mapping[str, Any]) -> BaseLanguageModel:
+    provider = str(config.get("provider", settings.llm_provider)).lower()
+    model_name = str(config.get("model", settings.llm_model))
+    temperature = float(config.get("temperature", settings.llm_temperature))
+    logger.info("Initialising %s provider with model %s", provider, model_name)
 
     if provider == "ollama":
-        return Ollama(
-            base_url=settings.ollama_base_url,
-            model=settings.llm_model,
-            temperature=settings.llm_temperature,
-        )
+        base_url = str(config.get("base_url") or settings.ollama_base_url)
+        return Ollama(base_url=base_url, model=model_name, temperature=temperature)
     if provider == "vllm":
+        api_base = str(config.get("api_base") or config.get("vllm_api_base") or settings.vllm_api_base)
+        api_key = str(config.get("api_key") or settings.openai_api_key or "unused")
         return VLLMOpenAI(
-            openai_api_base=settings.vllm_api_base,
-            model_name=settings.llm_model,
-            temperature=settings.llm_temperature,
-            api_key=settings.openai_api_key or "unused",
+            openai_api_base=api_base,
+            model_name=model_name,
+            temperature=temperature,
+            api_key=api_key,
         )
     if provider == "openai":
+        api_key = config.get("api_key") or settings.openai_api_key
+        api_base = config.get("api_base") or settings.openai_api_base
         return ChatOpenAI(
-            model=settings.llm_model,
-            temperature=settings.llm_temperature,
-            openai_api_key=settings.openai_api_key,
-            openai_api_base=settings.openai_api_base,
+            model=model_name,
+            temperature=temperature,
+            openai_api_key=api_key,
+            openai_api_base=api_base,
         )
 
-    raise ValueError(f"Unsupported LLM provider: {settings.llm_provider}")
+    raise ValueError(f"Unsupported LLM provider: {provider}")

--- a/worker/tigerchain_app/rag/retriever.py
+++ b/worker/tigerchain_app/rag/retriever.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import json
 
-from typing import List
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Set
 
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
@@ -13,6 +16,13 @@ from ..ingestion.tigergraph import TigerGraphClient
 from ..utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass
+class RetrievalContext:
+    owner_id: Optional[str] = None
+    categories: Optional[Iterable[str]] = None
+    model_alias: Optional[str] = None
 
 
 class TigerGraphVectorRetriever(BaseRetriever):
@@ -28,6 +38,10 @@ class TigerGraphVectorRetriever(BaseRetriever):
         self.settings = settings
         self.embeddings = embeddings
         self.tigergraph_client = tigergraph_client
+        self._context: ContextVar[RetrievalContext | None] = ContextVar(
+            f"tg_retriever_filters_{id(self)}",
+            default=None,
+        )
 
     def _get_relevant_documents(self, query: str) -> List[Document]:  # type: ignore[override]
         logger.debug("Embedding query for retrieval")
@@ -41,6 +55,14 @@ class TigerGraphVectorRetriever(BaseRetriever):
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+    @contextmanager
+    def use_context(self, context: RetrievalContext):
+        token = self._context.set(context)
+        try:
+            yield
+        finally:  # pragma: no branch - ensure token reset
+            self._context.reset(token)
+
     def _parse_response(self, payload: dict) -> List[Document]:
         results = []
         for result in payload.get("results", []):
@@ -68,4 +90,32 @@ class TigerGraphVectorRetriever(BaseRetriever):
                         metadata=metadata,
                     )
                 )
-        return results
+        return self._filter_documents(results)
+
+    def _filter_documents(self, documents: List[Document]) -> List[Document]:
+        context = self._context.get()
+        if context is None:
+            return documents
+
+        owner_id = str(context.owner_id) if context.owner_id is not None else None
+        category_filters: Optional[Set[str]] = None
+        if context.categories:
+            category_filters = {str(cat).strip() for cat in context.categories if str(cat).strip()}
+        model_alias = context.model_alias
+
+        filtered: List[Document] = []
+        for doc in documents:
+            metadata = doc.metadata or {}
+            if owner_id is not None and str(metadata.get("owner_id")) != owner_id:
+                continue
+            if category_filters:
+                doc_categories = metadata.get("categories") or []
+                if isinstance(doc_categories, str):
+                    doc_categories = [doc_categories]
+                doc_category_set = {str(cat).strip() for cat in doc_categories if str(cat).strip()}
+                if not doc_category_set & category_filters:
+                    continue
+            if model_alias and metadata.get("model_alias") not in {model_alias, None}:
+                continue
+            filtered.append(doc)
+        return filtered

--- a/worker/tigerchain_app/utils/text.py
+++ b/worker/tigerchain_app/utils/text.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
 
 
 _SLUG_RE = re.compile(r"[^a-zA-Z0-9]+")
@@ -25,5 +25,8 @@ def ensure_unique_slug(base: str, existing: Iterable[str]) -> str:
     return f"{candidate}-{index}"
 
 
-def resolve_document_id(path: Path, existing: Iterable[str]) -> str:
-    return ensure_unique_slug(path.stem, existing)
+def resolve_document_id(path: Path, existing: Iterable[str], owner: Optional[str] = None) -> str:
+    base = path.stem
+    if owner:
+        base = f"{owner}-{base}"
+    return ensure_unique_slug(base, existing)


### PR DESCRIPTION
## Summary
- implement SQLModel-backed authentication, onboarding, and document tracking APIs for FastAPI endpoints
- orchestrate multiple retrieval agents with configurable model registry and per-user filtering
- enhance ingestion pipeline, chunking, CLI, and docs to capture user metadata and agent selections

## Testing
- python -m compileall worker

------
https://chatgpt.com/codex/tasks/task_e_68d294a35ed483259e98b03f6af161ed