### PR TITLE
Add dual embedding ingestion and private uploader design

### DIFF
--- a/docs/private_embeddings_architecture.md
+++ b/docs/private_embeddings_architecture.md
@@ -1,0 +1,48 @@
+# Private + Public Embedding Architecture
+
+The ingestion service now maintains two distinct vector representations for every chunked document: a dense embedding for collaborative scenarios and a bitwise embedding for highly sensitive flows. This document summarises the changes across storage, APIs, and retrieval.
+
+## Storage pipeline
+
+1. **Upload to MinIO** – Source files continue to be streamed to the configured MinIO bucket using the logical key `<doc_id>/<filename>`.
+2. **Chunking** – The adaptive chunker produces `ChunkRow` instances tagged with:
+   - `submission_id` – stable identifier applied to every chunk in the submission.
+   - `embedding_scope` – user-selected value (`public`, `private`, or `both`).
+3. **Embedding generation** – The new `DualEmbeddingProvider` wraps the HuggingFace model and produces:
+   - Dense vectors for traditional similarity search.
+   - Bitwise vectors (thresholded) suitable for private, shareable fingerprints.
+4. **Graph persistence** – Both vectors and the submission ID are stored as attributes on the `Document` vertex within TigerGraph. Metadata continues to hold owner/category information for filtering.
+5. **Private artifact** – For every document we persist an aggregated JSON payload (`<doc_id>/private_embeddings/<submission_id>.json`) into MinIO containing the ordered bitwise embeddings per chunk. The URI is recorded in both metadata and the SQL metadata store for audit purposes.
+
+## API surface
+
+### Ingestion endpoint (`POST /ingest`)
+
+New form fields provide fine-grained control:
+
+- `embedding_scope`: dictates which embedding mode should be used during retrieval defaults to `both` (store both sets, prefer public for RAG).
+- `sharing_preference`: captures the share policy (`public`, `private`, `both`). Stored alongside the document record.
+- `submission_id`: optional client-specified tag; if omitted the service generates one automatically.
+
+The response now includes the submission ID, chosen scope, and the MinIO URI for the private embedding artifact.
+
+### Query endpoint (`POST /query`)
+
+Clients can request either embedding set by setting `embedding_scope` (`public` or `private`). The retriever honours this preference by:
+
+1. Embedding the query with the appropriate mode (bitwise vs dense).
+2. Routing the request to TigerGraph with the new `embedding_type` parameter.
+3. Filtering source documents so only chunks tagged with the requested scope (`public`/`private`/`both`) are returned.
+
+## Metadata persistence
+
+- **SQL metadata** – `document_uploads` includes `submission_id`, `embedding_scope`, `sharing_preference`, and `private_embedding_uri` for UI consumption and audit trails.
+- **TigerGraph** – Additional attributes (`private_embedding`, `submission_id`) enrich downstream analytics and allow server-side filtering for scoped retrieval.
+- **MinIO** – Stores both the raw files and the JSON snapshot of bitwise embeddings for reproducibility and offline inspection.
+
+## Operational considerations
+
+- `bitwise_threshold` in `Settings` can be tuned per environment to control bit density.
+- The JSON artifacts enable rebuilds of private indices without re-embedding entire documents.
+- Future work: enforce access policies on the MinIO private embedding prefix and add lifecycle policies for aging out unused submissions.
+

--- a/docs/ui/document_uploader.md
+++ b/docs/ui/document_uploader.md
@@ -1,0 +1,56 @@
+# Private Document Uploader Design Iteration
+
+This document captures the updated interaction model for the private document ingestion experience. The goal is to give each user a clear sense of what happens to their files, which embedding sets are generated, and how sharing works across public and private contexts.
+
+## Primary user flow
+
+1. **Landing state** – When a user opens the uploader modal they see:
+   - Drag-and-drop zone with explicit "Private by default" badge.
+   - Checklist summarising what will happen during ingestion (MinIO storage, dense + bitwise embeddings, submission ID tagging).
+   - Quick links to organisation-wide retention policies.
+2. **File selection** – Once files are added the right-hand summary pane lights up showing:
+   - Total files and aggregate size.
+   - Auto-generated submission ID (with option to override before upload).
+   - Drop-down to choose the *sharing preference* (`Public`, `Private`, `Dual`).
+   - Toggle to decide which embedding set should drive RAG for future queries.
+3. **Metadata enrichment** – Users can assign:
+   - Primary category (chips with autocomplete from their saved categories).
+   - Additional tags (multi-select input with free-form option).
+   - Optional JSON metadata editor (with schema validation and copy/paste support).
+4. **Security review step** – Before upload the modal surfaces:
+   - A diff-style view comparing public vs bitwise embeddings (only summary stats, not raw vectors).
+   - Call-outs indicating where private embeddings will be stored (MinIO path + guardrails).
+   - Confirmation checkbox to acknowledge sharing preference.
+5. **Upload progress** – Progress bar per file and overall submission with two tabs:
+   - *Source Upload* (streaming to MinIO).
+   - *Embedding Generation* (dense + bitwise progress, with chunk count display).
+6. **Completion state** – Displays:
+   - Submission ID and timestamp.
+   - Links to MinIO object, private embedding JSON artifact, and recent RAG activity.
+   - Buttons to share public embedding, share private embedding (if allowed), or revoke access.
+
+## Component inventory
+
+| Component | Purpose | Notes |
+|-----------|---------|-------|
+| `UploaderDropZone` | Accepts file drop or click-to-upload. | Surface badge showing encryption status. |
+| `SubmissionSummaryCard` | Shows submission ID, size, categories. | Allows editing submission ID before final confirmation. |
+| `EmbeddingPreferenceSelector` | Radio buttons for query-time embedding scope (public vs private). | Persists preference to user profile for default retrieval. |
+| `SharingPreferenceSelector` | Multi-option segmented control (`Public`, `Private`, `Dual`). | Drives the `sharing_preference` persisted with each document. |
+| `MetadataForm` | Collects categories, tags, JSON metadata. | Validates JSON in-line and surfaces errors before upload. |
+| `SecurityChecklist` | Highlights where assets live and what data is generated. | Links to audit log and MinIO bucket explorer. |
+| `UploadProgressPanel` | Streams ingestion updates (chunk counts, MinIO URIs). | Splits progress by stage to help debug slow embedding steps. |
+| `CompletionActions` | Final screen actions to share/revoke embeddings. | Exposes copy-to-clipboard for submission ID and API endpoint. |
+
+## Responsive considerations
+
+- On mobile the metadata form collapses into accordion sections; the security checklist becomes a swipeable carousel.
+- Progress panel converts to stacked cards with inline status icons.
+- Completion actions compress into a vertical button stack with icons and short labels.
+
+## Future enhancements
+
+- Inline preview of extracted text chunks with toggle to view bitwise representation heatmaps.
+- Activity timeline that shows when public or private embeddings were shared and with whom.
+- Integration with notification system to alert when someone accesses a shared embedding set.
+

--- a/gsql/queries.gsql
+++ b/gsql/queries.gsql
@@ -79,7 +79,41 @@ CREATE QUERY TopKSimilarChunks(LIST<FLOAT> q, INT topk) FOR GRAPH DocGraph SYNTA
                 (CASE WHEN (R.@norm*R.@qnorm)==0 THEN 0 ELSE (R.@dot/(R.@norm*R.@qnorm)) END) AS score];
 }
 
+CREATE QUERY SimilarChunks(LIST<FLOAT> q, INT topk, STRING embedding_type) FOR GRAPH DocGraph SYNTAX v2 {
+  SumAccum<FLOAT> @dot; SumAccum<FLOAT> @norm; SumAccum<FLOAT> @qnorm;
+  FLOAT qnorm = 0.0; INT n = q.size(); INT i = 0;
+  WHILE i < n DO qnorm += q[i]*q[i]; i = i + 1; END; qnorm = sqrt(qnorm);
+
+  Start = {Document.*};
+  Start = SELECT d FROM Start:d POST-ACCUM
+    d.@dot=0.0, d.@norm=0.0, d.@qnorm=qnorm,
+    i=0, WHILE i<n DO
+      CASE
+        WHEN embedding_type == "private" THEN
+          CASE WHEN i<d.private_embedding.size() THEN
+            d.@dot += d.private_embedding[i]*q[i];
+            d.@norm += d.private_embedding[i]*d.private_embedding[i];
+          END
+        ELSE
+          CASE WHEN i<d.embedding.size() THEN
+            d.@dot += d.embedding[i]*q[i];
+            d.@norm += d.embedding[i]*d.embedding[i];
+          END
+      END, i=i+1 END;
+
+  Ranked = SELECT d FROM Start:d
+    ACCUM d.@norm = sqrt(d.@norm)
+    ORDER BY CASE WHEN (d.@norm*d.@qnorm)==0 THEN 0 ELSE (d.@dot/(d.@norm*d.@qnorm)) END DESC LIMIT topk;
+
+  PRINT Ranked[Ranked.id AS id, Ranked.doc_id AS doc_id, Ranked.chunk_id AS chunk_id, Ranked.title AS title,
+               Ranked.source AS source, Ranked.uri AS uri, Ranked.http_url AS http_url,
+               Ranked.metadata AS metadata, Ranked.content AS content,
+               Ranked.submission_id AS submission_id,
+               (CASE WHEN (Ranked.@norm*Ranked.@qnorm)==0 THEN 0 ELSE (Ranked.@dot/(Ranked.@norm*Ranked.@qnorm)) END) AS score];
+}
+
 INSTALL QUERY TopKSimilarDocs
 INSTALL QUERY TopKSimilarPages
 INSTALL QUERY TopKSimilarChunks
+INSTALL QUERY SimilarChunks
 

--- a/gsql/schema.gsql
+++ b/gsql/schema.gsql
@@ -9,6 +9,15 @@ CREATE VERTEX Document (
   text STRING,
   pages INT,
   doc_embedding LIST<FLOAT>   # NEW
+  , source STRING
+  , content STRING
+  , metadata STRING
+  , embedding LIST<FLOAT>
+  , private_embedding LIST<INT>
+  , submission_id STRING
+  , created_at STRING
+  , doc_id STRING
+  , chunk_id INT
 ) WITH PRIMARY_ID_AS_ATTRIBUTE="TRUE"
 
 # Page-level aggregated embedding (one per page)

--- a/worker/tigerchain_app/agents/orchestrator.py
+++ b/worker/tigerchain_app/agents/orchestrator.py
@@ -21,6 +21,7 @@ class QueryContext:
     owner_id: Optional[str] = None
     categories: Optional[Iterable[str]] = None
     model_alias: Optional[str] = None
+    embedding_scope: Optional[str] = None
 
 
 @dataclass
@@ -62,6 +63,7 @@ class RagAgent:
             owner_id=context.owner_id,
             categories=categories,
             model_alias=context.model_alias or self.name,
+            embedding_scope=context.embedding_scope,
         )
         logger.debug("Agent %s executing query with filters: %s", self.name, retrieval_context)
         with retriever.use_context(retrieval_context):

--- a/worker/tigerchain_app/auth/models.py
+++ b/worker/tigerchain_app/auth/models.py
@@ -39,4 +39,8 @@ class DocumentUpload(SQLModel, table=True):
     object_uri: Optional[str] = Field(default=None)
     http_url: Optional[str] = Field(default=None)
     metadata: dict = Field(default_factory=dict, sa_column=Column(JSON))
+    submission_id: Optional[str] = Field(default=None, index=True)
+    embedding_scope: Optional[str] = Field(default=None, index=True)
+    sharing_preference: Optional[str] = Field(default=None, index=True)
+    private_embedding_uri: Optional[str] = Field(default=None)
     created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)

--- a/worker/tigerchain_app/auth/schemas.py
+++ b/worker/tigerchain_app/auth/schemas.py
@@ -52,6 +52,10 @@ class DocumentRecord(BaseModel):
     object_uri: Optional[str]
     http_url: Optional[str]
     metadata: Optional[dict]
+    submission_id: Optional[str]
+    embedding_scope: Optional[str]
+    sharing_preference: Optional[str]
+    private_embedding_uri: Optional[str]
     created_at: datetime
 
     class Config:

--- a/worker/tigerchain_app/auth/service.py
+++ b/worker/tigerchain_app/auth/service.py
@@ -102,6 +102,10 @@ class DocumentService:
         object_uri: Optional[str],
         http_url: Optional[str],
         metadata: Optional[dict] = None,
+        submission_id: Optional[str] = None,
+        embedding_scope: Optional[str] = None,
+        sharing_preference: Optional[str] = None,
+        private_embedding_uri: Optional[str] = None,
     ) -> DocumentUpload:
         record = DocumentUpload(
             user_id=user_id,
@@ -112,6 +116,10 @@ class DocumentService:
             object_uri=object_uri,
             http_url=http_url,
             metadata=metadata or {},
+            submission_id=submission_id,
+            embedding_scope=embedding_scope,
+            sharing_preference=sharing_preference,
+            private_embedding_uri=private_embedding_uri,
         )
         self.session.add(record)
         self.session.commit()

--- a/worker/tigerchain_app/config.py
+++ b/worker/tigerchain_app/config.py
@@ -37,6 +37,13 @@ class Settings(BaseSettings):
     embed_batch_size: int = Field(default=32, description="Batch size for embedding generation")
     chunk_size: int = Field(default=900, description="Character chunk size for document splitting")
     chunk_overlap: int = Field(default=150, description="Chunk overlap for recursive splitter")
+    bitwise_threshold: float = Field(
+        default=0.0,
+        description=(
+            "Threshold used to convert dense embeddings into bitwise private embeddings. "
+            "Values greater than or equal to the threshold are mapped to 1, others to 0."
+        ),
+    )
 
     # Retrieval
     top_k: int = Field(default=5, description="Number of similar chunks to fetch per query")

--- a/worker/tigerchain_app/ingestion/embeddings.py
+++ b/worker/tigerchain_app/ingestion/embeddings.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Iterable, List, Sequence, Tuple
+
 from langchain_community.embeddings import HuggingFaceEmbeddings
 from langchain_core.embeddings import Embeddings
 
@@ -9,14 +11,55 @@ from ..utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-def create_embeddings(settings: Settings) -> Embeddings:
+class DualEmbeddingProvider(Embeddings):
+    """Wrapper that generates dense and bitwise embeddings in tandem."""
+
+    def __init__(self, base: Embeddings, *, bitwise_threshold: float) -> None:
+        self._base = base
+        self._threshold = bitwise_threshold
+
+    # ------------------------------------------------------------------
+    # Standard embedding interface
+    # ------------------------------------------------------------------
+    def embed_documents(self, texts: Sequence[str]) -> List[List[float]]:  # type: ignore[override]
+        # Returning the dense embeddings maintains compatibility with callers that
+        # expect the LangChain Embeddings protocol. Additional helpers expose the
+        # paired private representation.
+        dense = self._base.embed_documents(texts)
+        return dense
+
+    def embed_query(self, text: str) -> List[float]:  # type: ignore[override]
+        return self._base.embed_query(text)
+
+    # ------------------------------------------------------------------
+    # Extended helpers
+    # ------------------------------------------------------------------
+    def embed_documents_with_private(
+        self, texts: Sequence[str]
+    ) -> Tuple[List[List[float]], List[List[int]]]:
+        dense_vectors = self._base.embed_documents(texts)
+        private_vectors = [self._to_bitwise(vector) for vector in dense_vectors]
+        return dense_vectors, private_vectors
+
+    def embed_query_with_mode(self, text: str, mode: str) -> List[float | int]:
+        if mode == "private":
+            return self._to_bitwise(self._base.embed_query(text))
+        return self._base.embed_query(text)
+
+    def _to_bitwise(self, vector: Iterable[float]) -> List[int]:
+        threshold = self._threshold
+        return [1 if value >= threshold else 0 for value in vector]
+
+
+def create_embeddings(settings: Settings) -> DualEmbeddingProvider:
     logger.info("Loading embedding model %s", settings.embed_model)
     model_kwargs = {}
     if settings.embed_device:
         model_kwargs["device"] = settings.embed_device
     encode_kwargs = {"batch_size": settings.embed_batch_size}
-    return HuggingFaceEmbeddings(
+    base = HuggingFaceEmbeddings(
         model_name=settings.embed_model,
         model_kwargs=model_kwargs,
         encode_kwargs=encode_kwargs,
     )
+    return DualEmbeddingProvider(base, bitwise_threshold=settings.bitwise_threshold)

--- a/worker/tigerchain_app/ingestion/storage.py
+++ b/worker/tigerchain_app/ingestion/storage.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from io import BytesIO
 from pathlib import Path
 from typing import Tuple
 
@@ -38,6 +40,18 @@ class MinioObjectStore(ObjectStore):
 
     def upload(self, path: Path, key: str) -> Tuple[str, str]:
         self.client.upload_file(str(path), self.settings.minio_bucket, key)
+        uri = f"s3://{self.settings.minio_bucket}/{key}"
+        http_url = f"{self.settings.minio_endpoint.rstrip('/')}/{self.settings.minio_bucket}/{key}"
+        return uri, http_url
+
+    def upload_json(self, payload: dict, key: str) -> Tuple[str, str]:
+        body = json.dumps(payload).encode("utf-8")
+        self.client.put_object(
+            Bucket=self.settings.minio_bucket,
+            Key=key,
+            Body=BytesIO(body),
+            ContentType="application/json",
+        )
         uri = f"s3://{self.settings.minio_bucket}/{key}"
         http_url = f"{self.settings.minio_endpoint.rstrip('/')}/{self.settings.minio_bucket}/{key}"
         return uri, http_url

--- a/worker/tigerchain_app/ingestion/tigergraph.py
+++ b/worker/tigerchain_app/ingestion/tigergraph.py
@@ -60,12 +60,12 @@ class TigerGraphClient:
         for row in rows:
             self.conn.upsertVertex("Document", row.id, row.to_upsert_payload()["attributes"])
 
-    def top_k_similar(self, embedding: Iterable[float], top_k: int) -> dict:
+    def top_k_similar(self, embedding: Iterable[float | int], top_k: int, embedding_type: str = "public") -> dict:
         token = self.get_token()
         response = requests.post(
             f"http://{self.settings.tg_host}:{self.settings.tg_rest_port}/query/{self.settings.tg_graph}/SimilarChunks",
             headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
-            json={"query_embedding": list(embedding), "topk": top_k},
+            json={"query_embedding": list(embedding), "topk": top_k, "embedding_type": embedding_type},
             timeout=120,
         )
         response.raise_for_status()


### PR DESCRIPTION
## Summary
- generate dense and bitwise embeddings during ingestion, tagging chunks with submission IDs and persisting private vectors to MinIO and TigerGraph
- extend ingestion and query APIs plus metadata models to track embedding scope/sharing and allow private retrieval
- document the private uploader UX iteration and architecture updates while updating GSQL schema/queries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4b88f22a083258450714e3c03d02e