### PR TITLE
Enhance ingestion pipeline and CLI UX with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ The `rag-api` container image bundles a Typer CLI for local operations. Use
 
 - `make ingest` – embed and upsert all files under `worker/sample_docs` (supports `--owner`, `--agent`, and `--category`).
 - `make query Q="..."` – run an ad-hoc question against TigerGraph-stored data with optional `--agent`, `--mode`, and `--category` filters.
+- `docker compose run --rm rag-api python cli.py agents` – inspect the configured agent registry.
+
+The CLI now prints a concise ingestion summary highlighting chunk counts, file sizes, and private embedding artifacts for each processed document. The `query` command also accepts `--json` to emit machine-readable responses for automation workflows.
 
 ## API Endpoints
 
@@ -154,6 +157,22 @@ Embeddings default to `sentence-transformers/all-MiniLM-L6-v2`. Override with
 `EMBED_MODEL`, `EMBED_DEVICE`, and `EMBED_BATCH_SIZE` to match hardware. The
 `BITWISE_THRESHOLD` setting controls how dense vectors are binarised for private
 embedding generation.
+
+## Testing & Coverage
+
+Unit tests live under `worker/tests` and can be executed locally without the
+full container stack:
+
+```bash
+cd worker
+pytest
+```
+
+To generate coverage metrics, install `pytest-cov` and run:
+
+```bash
+pytest --cov=tigerchain_app --cov=cli --cov-report=term-missing
+```
 
 ## Authentication & Persistence
 

--- a/worker/cli.py
+++ b/worker/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import Counter
 import json
 from pathlib import Path
 from typing import List, Optional
@@ -13,6 +14,25 @@ from tigerchain_app.utils.logging import configure_logging, get_logger
 
 app = typer.Typer(help="TigerChain CLI utilities")
 logger = get_logger(__name__)
+
+
+def _validate_mode(value: str) -> str:
+    choice = value.lower().strip()
+    if choice not in {"sequential", "parallel"}:
+        raise typer.BadParameter("mode must be 'sequential' or 'parallel'")
+    return choice
+
+
+def _format_bytes(size: int) -> str:
+    if size < 1024:
+        return f"{size} B"
+    units = ["KB", "MB", "GB", "TB"]
+    value = float(size)
+    for unit in units:
+        value /= 1024.0
+        if value < 1024 or unit == units[-1]:
+            return f"{value:.1f} {unit}"
+    return f"{value:.1f} PB"
 
 
 @app.command()
@@ -35,15 +55,40 @@ def ingest(
         logger.info("Ingesting file %s", path)
         result = pipeline.ingest_files([path], owner_id=owner, categories=category, model_alias=agent)
     typer.echo(f"Ingested {len(result.chunks)} chunks from {len(result.documents)} document(s)")
+    if result.documents:
+        typer.echo("\nIngestion summary:")
+        chunk_counts = Counter(row.doc_id for row in result.chunks)
+        for summary in result.documents:
+            chunk_total = chunk_counts.get(summary.doc_id, 0)
+            typer.echo(
+                f"- {summary.doc_id} · {summary.source_path.name} · {chunk_total} chunk(s) · "
+                f"{_format_bytes(summary.file_size_bytes)} · scope={summary.embedding_scope}"
+            )
+            if summary.categories:
+                typer.echo(f"  Categories: {', '.join(summary.categories)}")
+            typer.echo(f"  Object URI: {summary.uri}")
+            if summary.private_embedding_uri:
+                typer.echo(f"  Private embeddings: {summary.private_embedding_uri}")
 
 
 @app.command()
 def query(
     question: str = typer.Argument(..., help="Natural language question to ask"),
     agent: Optional[str] = typer.Option(None, "--agent", help="Agent/model alias to execute the query"),
-    mode: str = typer.Option("sequential", "--mode", help="Execution mode: sequential or parallel"),
+    mode: str = typer.Option(
+        "sequential",
+        "--mode",
+        help="Execution mode: sequential or parallel",
+        show_default=True,
+        callback=_validate_mode,
+    ),
     owner: Optional[str] = typer.Option(None, "--owner", help="Optional owner identifier to filter results"),
     category: List[str] = typer.Option([], "--category", help="Filter results by categories"),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Return the raw JSON response instead of a formatted summary",
+    ),
 ) -> None:
     """Execute retrieval-augmented generation over TigerGraph content."""
 
@@ -73,7 +118,42 @@ def query(
     }
     if output["results"]:
         output["answer"] = output["results"][0]["answer"]
-    typer.echo(json.dumps(output, indent=2))
+    if json_output:
+        typer.echo(json.dumps(output, indent=2))
+        return
+
+    typer.echo(f"Question: {question}")
+    for item in output["results"]:
+        typer.echo(f"\nAgent: {item['agent']}")
+        typer.echo(f"Answer: {item['answer'] or 'No answer returned'}")
+        sources = item.get("sources") or []
+        if sources:
+            typer.echo("Sources:")
+            for source in sources:
+                label = source.get("title") or source.get("source") or "Unknown"
+                uri = source.get("http_url") or source.get("uri")
+                score = source.get("score")
+                details = f"  - {label}"
+                if uri:
+                    details += f" ({uri})"
+                if score is not None:
+                    details += f" [score={score}]"
+                typer.echo(details)
+
+
+@app.command("agents")
+def list_agents() -> None:
+    """List configured agent aliases available for querying."""
+
+    configure_logging()
+    context = build_context(force=True)
+    names = context.agent_orchestrator.available_agents()
+    if not names:
+        typer.echo("No agents are currently configured.")
+        return
+    typer.echo("Available agents:")
+    for name in names:
+        typer.echo(f"- {name}")
 
 
 if __name__ == "__main__":

--- a/worker/pytest.ini
+++ b/worker/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -ra
+pythonpath = .
+testpaths = tests

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -10,6 +10,11 @@ pandas==2.2.2
 sentence-transformers==2.7.0
 # (Installs torch + transformers as needed; for GPUs you can override in Docker)
 
+# LangChain stack
+langchain==0.2.16
+langchain-community==0.2.16
+langchain-text-splitters==0.2.2
+
 # Storage / PDFs
 boto3==1.34.162
 PyMuPDF==1.24.9
@@ -21,3 +26,7 @@ python-multipart==0.0.9
 sqlmodel==0.0.21
 passlib[bcrypt]==1.7.4
 python-jose==3.3.0
+
+# Tooling & tests
+pytest==8.2.2
+pytest-cov==5.0.0

--- a/worker/server.py
+++ b/worker/server.py
@@ -56,6 +56,8 @@ class IngestedDocumentResponse(BaseModel):
     private_embedding_uri: Optional[str]
     embedding_scope: str
     sharing_preference: str
+    file_size_bytes: Optional[int] = None
+    source_checksum: Optional[str] = None
 
 
 class IngestResponse(BaseModel):
@@ -179,6 +181,8 @@ async def ingest_documents(
                 private_embedding_uri=record.private_embedding_uri or summary.private_embedding_uri,
                 embedding_scope=record.embedding_scope or summary.embedding_scope,
                 sharing_preference=record.sharing_preference or sharing_preference,
+                file_size_bytes=summary.file_size_bytes,
+                source_checksum=summary.source_checksum,
             )
         )
 

--- a/worker/tests/test_ingestion_pipeline.py
+++ b/worker/tests/test_ingestion_pipeline.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import sys
+import types
+from pathlib import Path
+from typing import Iterable, List
+
+import pytest
+
+
+def _install_langchain_stubs() -> None:
+    if "langchain_core.embeddings" not in sys.modules:
+        module = types.ModuleType("langchain_core.embeddings")
+
+        class _Embeddings:  # pragma: no cover - runtime stub
+            def embed_documents(self, texts: List[str]) -> List[List[float]]:
+                raise NotImplementedError("LangChain embeddings are not installed")
+
+        module.Embeddings = _Embeddings  # type: ignore[attr-defined]
+        sys.modules[module.__name__] = module
+
+    if "langchain_core.documents" not in sys.modules:
+        module = types.ModuleType("langchain_core.documents")
+
+        @dataclass
+        class _Document:  # pragma: no cover - runtime stub
+            page_content: str
+            metadata: dict
+
+        module.Document = _Document  # type: ignore[attr-defined]
+        sys.modules[module.__name__] = module
+
+    if "langchain_text_splitters" not in sys.modules:
+        module = types.ModuleType("langchain_text_splitters")
+
+        class _RecursiveCharacterTextSplitter:  # pragma: no cover - runtime stub
+            def __init__(self, chunk_size: int, chunk_overlap: int) -> None:
+                self.chunk_size = chunk_size
+                self.chunk_overlap = chunk_overlap
+
+            def split_documents(self, documents: List[object]) -> List[object]:
+                return list(documents)
+
+        module.RecursiveCharacterTextSplitter = _RecursiveCharacterTextSplitter  # type: ignore[attr-defined]
+        sys.modules[module.__name__] = module
+
+    if "langchain_community.document_loaders" not in sys.modules:
+        module = types.ModuleType("langchain_community.document_loaders")
+
+        class _BaseLoader:  # pragma: no cover - runtime stub
+            def __init__(self, path: str, **_: object) -> None:
+                self.path = path
+
+            def load(self) -> list:
+                raise NotImplementedError
+
+        class _TextLoader(_BaseLoader):  # pragma: no cover - runtime stub
+            def load(self) -> list:
+                from langchain_core.documents import Document
+
+                content = Path(self.path).read_text(encoding="utf-8")
+                return [Document(page_content=content, metadata={"source": self.path})]
+
+        class _PyPDFLoader(_BaseLoader):  # pragma: no cover - runtime stub
+            pass
+
+        module.TextLoader = _TextLoader  # type: ignore[attr-defined]
+        module.PyPDFLoader = _PyPDFLoader  # type: ignore[attr-defined]
+        sys.modules[module.__name__] = module
+
+
+_install_langchain_stubs()
+
+from tigerchain_app.config import Settings
+from tigerchain_app.ingestion.pipeline import DocumentIngestionPipeline, EmbeddingScope
+
+
+class DummyEmbeddings:
+    def __init__(self, base_value: float = 0.5) -> None:
+        self.base_value = base_value
+        self.calls: List[List[str]] = []
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        self.calls.append(list(texts))
+        return [[self.base_value + index] for index, _ in enumerate(texts)]
+
+
+class DummyTigerGraphClient:
+    def __init__(self) -> None:
+        self.rows: List[object] = []
+
+    def upsert_chunk_rows(self, rows: Iterable[object]) -> None:
+        self.rows.extend(rows)
+
+
+class DummyObjectStore:
+    def __init__(self) -> None:
+        self.uploaded: dict[str, tuple[Path, str]] = {}
+        self.uploaded_json: dict[str, dict] = {}
+
+    def upload(self, path: Path, key: str) -> tuple[str, str]:
+        self.uploaded[key] = (path, key)
+        return (f"s3://bucket/{key}", f"http://minio/bucket/{key}")
+
+    def upload_json(self, payload: dict, key: str) -> tuple[str, str]:
+        self.uploaded_json[key] = payload
+        return (f"s3://bucket/{key}", f"http://minio/bucket/{key}")
+
+
+@pytest.fixture()
+def pipeline(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DocumentIngestionPipeline:
+    embeddings = DummyEmbeddings()
+    client = DummyTigerGraphClient()
+    store = DummyObjectStore()
+    settings = Settings()
+
+    def _fake_loader(paths: Iterable[Path]) -> List[object]:
+        docs: List[object] = []
+        for path in paths:
+            docs.append(types.SimpleNamespace(page_content=path.read_text(), metadata={"source": str(path)}))
+        return docs
+
+    from tigerchain_app.ingestion import pipeline as pipeline_module
+
+    monkeypatch.setattr(pipeline_module, "load_documents", _fake_loader)
+
+    return DocumentIngestionPipeline(settings, embeddings, client, store)
+
+
+def test_ingest_files_populates_metadata(tmp_path: Path, pipeline: DocumentIngestionPipeline) -> None:
+    source = tmp_path / "example.txt"
+    source.write_text("Hello world")
+
+    result = pipeline.ingest_files([source], owner_id="user-1", categories=["alpha", "alpha"], embedding_scope="both")
+
+    assert result.chunks, "expected at least one chunk"
+    row = result.chunks[0]
+    assert "source_checksum" in row.metadata
+    assert row.metadata["source_file_size"] == source.stat().st_size
+    assert result.documents[0].source_checksum == row.metadata["source_checksum"]
+    assert result.documents[0].file_size_bytes == source.stat().st_size
+
+    store: DummyObjectStore = pipeline.object_store  # type: ignore[attr-defined]
+    assert store.uploaded_json, "private embeddings should be persisted in 'both' scope"
+
+
+def test_public_scope_skips_private_embeddings(tmp_path: Path, pipeline: DocumentIngestionPipeline) -> None:
+    source = tmp_path / "only_public.txt"
+    source.write_text("Content for public scope")
+
+    result = pipeline.ingest_files([source], embedding_scope=EmbeddingScope.PUBLIC)
+
+    assert all(not row.private_embedding for row in result.chunks)
+    store: DummyObjectStore = pipeline.object_store  # type: ignore[attr-defined]
+    assert not store.uploaded_json, "public scope should not persist private embeddings"
+
+
+def test_invalid_scope_raises(tmp_path: Path, pipeline: DocumentIngestionPipeline) -> None:
+    source = tmp_path / "invalid.txt"
+    source.write_text("content")
+
+    with pytest.raises(ValueError):
+        pipeline.ingest_files([source], embedding_scope="invalid-scope")


### PR DESCRIPTION
## Summary
- add embedding scope validation, checksum metadata, and timezone-aware timestamps to the ingestion pipeline
- improve the Typer CLI experience with richer summaries, JSON output, and an agent discovery command
- document the new workflow, add pytest defaults, and cover the pipeline with focused unit tests and langchain fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d54226a6a88325917ca072ac318a90