### PR TITLE
feat: add configurable agent builder with orchestrator governance

### DIFF
--- a/worker/tests/test_agent_builder.py
+++ b/worker/tests/test_agent_builder.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from sqlmodel import Field, Session, SQLModel, create_engine
+
+class _User(SQLModel, table=True):  # pragma: no cover - minimal user table for FK
+    __tablename__ = "users"
+
+    id: int | None = Field(default=None, primary_key=True)
+
+from tigerchain_app.agents.registry import AgentRegistryLoader
+from tigerchain_app.agents.service import AgentBuilderService
+from tigerchain_app.config import Settings
+
+
+def create_session():
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    return Session(engine)
+
+
+def test_agent_builder_registry_snapshot_contains_metadata():
+    settings = Settings()
+    with create_session() as session:
+        service = AgentBuilderService(session)
+        kb = service.create_knowledge_base(
+            {
+                "name": "Product Architecture",
+                "description": "Core diagrams",
+                "tags": ["architecture"],
+                "document_ids": ["doc::alpha"],
+            },
+            created_by=None,
+        )
+        agent = service.create_agent_profile(
+            {
+                "name": "architecture_planner",
+                "description": "Plans product evolution",
+                "role_type": "team_member",
+                "knowledge_base_id": kb.id,
+                "requires_human_validation": True,
+            },
+            created_by=None,
+        )
+        tool = service.create_tool_template(
+            {
+                "name": "roadmap-template",
+                "description": "Generates roadmap drafts",
+                "specification": {"entrypoint": "roadmap"},
+            },
+            created_by=None,
+        )
+        service.assign_tool_to_agent(agent.id, tool.id, {"scope": "global"})
+        service.upsert_validator(
+            {
+                "name": "Human Validator",
+                "contact": "validator@example.com",
+                "is_active": True,
+            },
+            created_by=None,
+        )
+
+        loader = AgentRegistryLoader(session, settings)
+        snapshot = loader.build_snapshot()
+
+        assert agent.name in snapshot.registry
+        agent_config = snapshot.registry[agent.name]
+        assert agent_config["knowledge_base"]["id"] == kb.id
+        assert agent_config["requires_human_validation"] is True
+        assert snapshot.validator["name"] == "Human Validator"
+        assert any(tool_item["name"] == "roadmap-template" for tool_item in snapshot.tools)

--- a/worker/tigerchain_app/agents/__init__.py
+++ b/worker/tigerchain_app/agents/__init__.py
@@ -1,9 +1,22 @@
-"""Multi-agent orchestration utilities."""
+"""Multi-agent orchestration and builder utilities."""
 
-from .orchestrator import AgentOrchestrator, AgentQueryResult, QueryContext
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     "AgentOrchestrator",
     "AgentQueryResult",
     "QueryContext",
+    "AgentRegistryLoader",
+    "AgentRegistrySnapshot",
 ]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - lazy import indirection
+    if name in {"AgentOrchestrator", "AgentQueryResult", "QueryContext"}:
+        module = import_module(".orchestrator", __name__)
+        return getattr(module, name)
+    if name in {"AgentRegistryLoader", "AgentRegistrySnapshot"}:
+        module = import_module(".registry", __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/worker/tigerchain_app/agents/models.py
+++ b/worker/tigerchain_app/agents/models.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+"""Database models supporting the configurable agent builder."""
+
+from datetime import datetime
+from typing import List, Optional
+
+from sqlalchemy import Column, UniqueConstraint
+from sqlalchemy.types import JSON
+from sqlmodel import Field, SQLModel
+
+
+class KnowledgeBase(SQLModel, table=True):
+    """Curated collections of documents or embeddings for an agent domain."""
+
+    __tablename__ = "knowledge_bases"
+    __table_args__ = (UniqueConstraint("name", name="uq_knowledge_bases_name"),)
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True)
+    description: Optional[str] = Field(default=None)
+    tags: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    document_ids: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    extra_metadata: dict = Field(default_factory=dict, sa_column=Column("metadata", JSON))
+    created_by: Optional[int] = Field(default=None, foreign_key="users.id", index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class AgentProfile(SQLModel, table=True):
+    """Configurable RAG agent definition exposed through the builder."""
+
+    __tablename__ = "agent_profiles"
+    __table_args__ = (UniqueConstraint("name", name="uq_agent_profiles_name"),)
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True)
+    display_name: Optional[str] = Field(default=None)
+    description: Optional[str] = Field(default=None)
+    role: Optional[str] = Field(default=None)
+    role_type: str = Field(default="chat", index=True)
+    system_prompt: Optional[str] = Field(default=None)
+    knowledge_base_id: Optional[int] = Field(default=None, foreign_key="knowledge_bases.id")
+    embedding_documents: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    extra_metadata: dict = Field(default_factory=dict, sa_column=Column("metadata", JSON))
+    tags: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    provider: Optional[str] = Field(default=None)
+    model: Optional[str] = Field(default=None)
+    temperature: Optional[float] = Field(default=None)
+    available_tools: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    requires_human_validation: bool = Field(default=True)
+    validator_instructions: Optional[str] = Field(default=None)
+    created_by: Optional[int] = Field(default=None, foreign_key="users.id", index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class AgentTeam(SQLModel, table=True):
+    """Container for multi-agent teams orchestrated together."""
+
+    __tablename__ = "agent_teams"
+    __table_args__ = (UniqueConstraint("name", name="uq_agent_teams_name"),)
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True)
+    description: Optional[str] = Field(default=None)
+    orchestrator_agent: Optional[str] = Field(default=None, index=True)
+    extra_metadata: dict = Field(default_factory=dict, sa_column=Column("metadata", JSON))
+    tags: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    created_by: Optional[int] = Field(default=None, foreign_key="users.id", index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class AgentTeamMember(SQLModel, table=True):
+    """Links an agent profile to a team with optional responsibilities."""
+
+    __tablename__ = "agent_team_members"
+    __table_args__ = (UniqueConstraint("team_id", "agent_id", name="uq_agent_team_membership"),)
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    team_id: int = Field(foreign_key="agent_teams.id", index=True)
+    agent_id: int = Field(foreign_key="agent_profiles.id", index=True)
+    priority: int = Field(default=0, index=True)
+    responsibilities: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    extra_metadata: dict = Field(default_factory=dict, sa_column=Column("metadata", JSON))
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class ToolTemplate(SQLModel, table=True):
+    """Reusable MCP tool templates shared across agents."""
+
+    __tablename__ = "tool_templates"
+    __table_args__ = (UniqueConstraint("name", name="uq_tool_templates_name"),)
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True)
+    description: Optional[str] = Field(default=None)
+    specification: dict = Field(default_factory=dict, sa_column=Column(JSON))
+    tags: List[str] = Field(default_factory=list, sa_column=Column(JSON))
+    is_mcp: bool = Field(default=True, index=True)
+    extra_metadata: dict = Field(default_factory=dict, sa_column=Column("metadata", JSON))
+    created_by: Optional[int] = Field(default=None, foreign_key="users.id", index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class AgentToolAssignment(SQLModel, table=True):
+    """Associates tool templates with agents and captures usage scope."""
+
+    __tablename__ = "agent_tool_assignments"
+    __table_args__ = (UniqueConstraint("agent_id", "tool_id", name="uq_agent_tool_assignment"),)
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    agent_id: int = Field(foreign_key="agent_profiles.id", index=True)
+    tool_id: int = Field(foreign_key="tool_templates.id", index=True)
+    scope: str = Field(default="global")
+    extra_metadata: dict = Field(default_factory=dict, sa_column=Column("metadata", JSON))
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class ValidatorProfile(SQLModel, table=True):
+    """Represents a human validator integrated into the orchestration flow."""
+
+    __tablename__ = "validator_profiles"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True)
+    role_description: Optional[str] = Field(default=None)
+    contact: Optional[str] = Field(default=None)
+    instructions: Optional[str] = Field(default=None)
+    extra_metadata: dict = Field(default_factory=dict, sa_column=Column("metadata", JSON))
+    is_active: bool = Field(default=True, index=True)
+    created_by: Optional[int] = Field(default=None, foreign_key="users.id", index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)

--- a/worker/tigerchain_app/agents/registry.py
+++ b/worker/tigerchain_app/agents/registry.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+"""Utilities for loading agent builder configuration from persistent storage."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from sqlmodel import Session, select
+
+from ..config import Settings
+from .models import (
+    AgentProfile,
+    AgentTeam,
+    AgentTeamMember,
+    AgentToolAssignment,
+    KnowledgeBase,
+    ToolTemplate,
+    ValidatorProfile,
+)
+
+
+@dataclass
+class AgentRegistrySnapshot:
+    """Aggregated view of the agent builder state."""
+
+    registry: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    knowledge_bases: List[Dict[str, Any]] = field(default_factory=list)
+    teams: List[Dict[str, Any]] = field(default_factory=list)
+    tools: List[Dict[str, Any]] = field(default_factory=list)
+    validator: Optional[Dict[str, Any]] = None
+    orchestrator_agent: Optional[str] = None
+
+
+class AgentRegistryLoader:
+    """Builds registry snapshots from SQLModel storage."""
+
+    def __init__(self, session: Session, settings: Settings) -> None:
+        self.session = session
+        self.settings = settings
+
+    def build_snapshot(self) -> AgentRegistrySnapshot:
+        knowledge_bases = self._load_knowledge_bases()
+        tools = self._load_tools()
+        tool_map = {tool["id"]: tool for tool in tools}
+        validator = self._load_validator()
+        profiles = self._load_agent_profiles()
+        assignments = self._load_assignments()
+        teams = self._load_teams()
+
+        registry: Dict[str, Dict[str, Any]] = {}
+        orchestrator_agent: Optional[str] = None
+
+        kb_map = {kb["id"]: kb for kb in knowledge_bases}
+        agent_tools: Dict[int, List[Dict[str, Any]]] = {}
+        for assignment in assignments:
+            agent_tools.setdefault(assignment["agent_id"], []).append(
+                {
+                    "tool_id": assignment["tool_id"],
+                    "tool": tool_map.get(assignment["tool_id"]),
+                    "scope": assignment["scope"],
+                    "metadata": assignment["metadata"],
+                }
+            )
+
+        for profile in profiles:
+            kb_details = kb_map.get(profile["knowledge_base_id"]) if profile["knowledge_base_id"] else None
+            config: Dict[str, Any] = {
+                "provider": profile["provider"] or self.settings.llm_provider,
+                "model": profile["model"] or self.settings.llm_model,
+                "temperature": profile["temperature"] if profile["temperature"] is not None else self.settings.llm_temperature,
+                "role": profile["role"],
+                "role_type": profile["role_type"],
+                "system_prompt": profile["system_prompt"],
+                "knowledge_base": kb_details,
+                "metadata": profile["metadata"],
+                "tags": profile["tags"],
+                "embedding_documents": profile["embedding_documents"],
+                "available_tools": profile["available_tools"],
+                "requires_human_validation": profile["requires_human_validation"],
+                "validator_instructions": profile["validator_instructions"],
+            }
+            if profile["id"] in agent_tools:
+                config["tools"] = agent_tools[profile["id"]]
+            registry[profile["name"]] = config
+            if profile["role_type"] == "orchestrator":
+                orchestrator_agent = profile["name"]
+
+        snapshot = AgentRegistrySnapshot(
+            registry=registry,
+            knowledge_bases=knowledge_bases,
+            teams=teams,
+            tools=tools,
+            validator=validator,
+            orchestrator_agent=orchestrator_agent,
+        )
+        return snapshot
+
+    # ------------------------------------------------------------------
+    # Load helpers
+    # ------------------------------------------------------------------
+    def _load_knowledge_bases(self) -> List[Dict[str, Any]]:
+        results = self.session.exec(select(KnowledgeBase)).all()
+        payload: List[Dict[str, Any]] = []
+        for kb in results:
+            payload.append(
+                {
+                    "id": kb.id,
+                    "name": kb.name,
+                    "description": kb.description,
+                    "tags": kb.tags,
+                    "document_ids": kb.document_ids,
+                    "metadata": kb.extra_metadata,
+                }
+            )
+        return payload
+
+    def _load_tools(self) -> List[Dict[str, Any]]:
+        results = self.session.exec(select(ToolTemplate)).all()
+        payload: List[Dict[str, Any]] = []
+        for tool in results:
+            payload.append(
+                {
+                    "id": tool.id,
+                    "name": tool.name,
+                    "description": tool.description,
+                    "specification": tool.specification,
+                    "tags": tool.tags,
+                    "is_mcp": tool.is_mcp,
+                    "metadata": tool.extra_metadata,
+                }
+            )
+        return payload
+
+    def _load_validator(self) -> Optional[Dict[str, Any]]:
+        result = self.session.exec(
+            select(ValidatorProfile).where(ValidatorProfile.is_active == True).order_by(ValidatorProfile.updated_at.desc())
+        ).first()
+        if not result:
+            return None
+        return {
+            "id": result.id,
+            "name": result.name,
+            "role_description": result.role_description,
+            "contact": result.contact,
+            "instructions": result.instructions,
+            "metadata": result.extra_metadata,
+        }
+
+    def _load_agent_profiles(self) -> List[Dict[str, Any]]:
+        results = self.session.exec(select(AgentProfile)).all()
+        payload: List[Dict[str, Any]] = []
+        for profile in results:
+            payload.append(
+                {
+                    "id": profile.id,
+                    "name": profile.name,
+                    "display_name": profile.display_name,
+                    "description": profile.description,
+                    "role": profile.role,
+                    "role_type": profile.role_type,
+                    "system_prompt": profile.system_prompt,
+                    "knowledge_base_id": profile.knowledge_base_id,
+                    "embedding_documents": profile.embedding_documents,
+                    "metadata": profile.extra_metadata,
+                    "tags": profile.tags,
+                    "provider": profile.provider,
+                    "model": profile.model,
+                    "temperature": profile.temperature,
+                    "available_tools": profile.available_tools,
+                    "requires_human_validation": profile.requires_human_validation,
+                    "validator_instructions": profile.validator_instructions,
+                }
+            )
+        return payload
+
+    def _load_assignments(self) -> List[Dict[str, Any]]:
+        results = self.session.exec(select(AgentToolAssignment)).all()
+        payload: List[Dict[str, Any]] = []
+        for assignment in results:
+            payload.append(
+                {
+                    "id": assignment.id,
+                    "agent_id": assignment.agent_id,
+                    "tool_id": assignment.tool_id,
+                    "scope": assignment.scope,
+                    "metadata": assignment.extra_metadata,
+                }
+            )
+        return payload
+
+    def _load_teams(self) -> List[Dict[str, Any]]:
+        teams = self.session.exec(select(AgentTeam)).all()
+        team_payload: List[Dict[str, Any]] = []
+        members = self.session.exec(select(AgentTeamMember)).all()
+        members_by_team: Dict[int, List[Dict[str, Any]]] = {}
+        for member in members:
+            members_by_team.setdefault(member.team_id, []).append(
+                {
+                    "id": member.id,
+                    "agent_id": member.agent_id,
+                    "priority": member.priority,
+                    "responsibilities": member.responsibilities,
+                    "metadata": member.extra_metadata,
+                }
+            )
+        for team in teams:
+            team_payload.append(
+                {
+                    "id": team.id,
+                    "name": team.name,
+                    "description": team.description,
+                    "orchestrator_agent": team.orchestrator_agent,
+                    "metadata": team.extra_metadata,
+                    "tags": team.tags,
+                    "members": members_by_team.get(team.id, []),
+                }
+            )
+        return team_payload

--- a/worker/tigerchain_app/agents/router.py
+++ b/worker/tigerchain_app/agents/router.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+"""FastAPI router implementing the agent builder API."""
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..auth.database import get_session
+from ..auth.models import User
+from ..auth.security import get_current_active_user
+from ..context import build_context
+from ..utils.logging import get_logger
+from .registry import AgentRegistryLoader
+from .schemas import (
+    AgentProfileCreate,
+    AgentProfileRead,
+    AgentProfileUpdate,
+    AgentTeamCreate,
+    AgentTeamRead,
+    AgentTeamUpdate,
+    KnowledgeBaseCreate,
+    KnowledgeBaseRead,
+    KnowledgeBaseUpdate,
+    RegistrySnapshotRead,
+    ToolAssignmentRequest,
+    ToolTemplateCreate,
+    ToolTemplateRead,
+    ValidatorProfileCreate,
+    ValidatorProfileRead,
+)
+from .service import AgentBuilderService
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/builder", tags=["agent-builder"])
+
+
+def _refresh_registry(context, session) -> RegistrySnapshotRead:
+    loader = AgentRegistryLoader(session, context.settings)
+    snapshot = loader.build_snapshot()
+    registry_data = dict(context.settings.model_registry)
+    registry_data.update(snapshot.registry)
+    context.settings.model_registry = registry_data
+    context.agent_orchestrator.refresh(snapshot)
+    return RegistrySnapshotRead(
+        registry=registry_data,
+        knowledge_bases=snapshot.knowledge_bases,
+        teams=snapshot.teams,
+        tools=snapshot.tools,
+        validator=snapshot.validator,
+        orchestrator_agent=snapshot.orchestrator_agent,
+    )
+
+
+@router.get("/knowledge-bases", response_model=List[KnowledgeBaseRead])
+def list_knowledge_bases(session=Depends(get_session), current_user: User = Depends(get_current_active_user)):
+    service = AgentBuilderService(session)
+    return [KnowledgeBaseRead.model_validate(kb) for kb in service.list_knowledge_bases()]
+
+
+@router.post("/knowledge-bases", response_model=KnowledgeBaseRead)
+def create_knowledge_base(
+    payload: KnowledgeBaseCreate,
+    session=Depends(get_session),
+    context=Depends(build_context),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = AgentBuilderService(session)
+    kb = service.create_knowledge_base(payload.model_dump(), created_by=current_user.id)
+    _refresh_registry(context, session)
+    return KnowledgeBaseRead.model_validate(kb)
+
+
+@router.patch("/knowledge-bases/{kb_id}", response_model=KnowledgeBaseRead)
+def update_knowledge_base(
+    kb_id: int,
+    payload: KnowledgeBaseUpdate,
+    session=Depends(get_session),
+    context=Depends(build_context),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = AgentBuilderService(session)
+    kb = service.update_knowledge_base(kb_id, payload.model_dump(exclude_unset=True))
+    _refresh_registry(context, session)
+    return KnowledgeBaseRead.model_validate(kb)
+
+
+@router.get("/agents", response_model=List[AgentProfileRead])
+def list_agents(session=Depends(get_session), current_user: User = Depends(get_current_active_user)):
+    service = AgentBuilderService(session)
+    return [AgentProfileRead.model_validate(agent) for agent in service.list_agent_profiles()]
+
+
+@router.post("/agents", response_model=AgentProfileRead)
+def create_agent(
+    payload: AgentProfileCreate,
+    session=Depends(get_session),
+    context=Depends(build_context),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = AgentBuilderService(session)
+    agent = service.create_agent_profile(payload.model_dump(), created_by=current_user.id)
+    _refresh_registry(context, session)
+    return AgentProfileRead.model_validate(agent)
+
+
+@router.patch("/agents/{agent_id}", response_model=AgentProfileRead)
+def update_agent(
+    agent_id: int,
+    payload: AgentProfileUpdate,
+    session=Depends(get_session),
+    context=Depends(build_context),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = AgentBuilderService(session)
+    agent = service.update_agent_profile(agent_id, payload.model_dump(exclude_unset=True))
+    _refresh_registry(context, session)
+    return AgentProfileRead.model_validate(agent)
+
+
+@router.post("/agents/{agent_id}/tools", response_model=AgentProfileRead)
+def assign_tools_to_agent(
+    agent_id: int,
+    payload: ToolAssignmentRequest,
+    session=Depends(get_session),
+    context=Depends(build_context),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = AgentBuilderService(session)
+    agent = service.get_agent_profile(agent_id)
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    assignment = service.assign_tool_to_agent(agent_id, payload.tool_id, payload.model_dump(exclude={"tool_id"}))
+    logger.info("Assigned tool %s to agent %s", assignment.tool_id, agent_id)
+    _refresh_registry(context, session)
+    refreshed = service.get_agent_profile(agent_id)
+    if refreshed is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return AgentProfileRead.model_validate(refreshed)
+
+
+@router.get("/tools", response_model=List[ToolTemplateRead])
+def list_tools(session=Depends(get_session), current_user: User = Depends(get_current_active_user)):
+    service = AgentBuilderService(session)
+    return [ToolTemplateRead.model_validate(tool) for tool in service.list_tool_templates()]
+
+
+@router.post("/tools", response_model=ToolTemplateRead)
+def create_tool(
+    payload: ToolTemplateCreate,
+    session=Depends(get_session),
+    context=Depends(build_context),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = AgentBuilderService(session)
+    tool = service.create_tool_template(payload.model_dump(), created_by=current_user.id)
+    _refresh_registry(context, session)
+    return ToolTemplateRead.model_validate(tool)
+
+
+@router.get("/teams", response_model=List[AgentTeamRead])
+def list_teams(session=Depends(get_session), current_user: User = Depends(get_current_active_user)):
+    service = AgentBuilderService(session)
+    teams = []
+    for team in service.list_agent_teams():
+        members = service.list_team_members(team.id)
+        team_dict = team.model_dump()
+        team_dict["members"] = [member.model_dump() for member in members]
+        teams.append(team_dict)
+    return [AgentTeamRead.model_validate(team) for team in teams]
+
+
+@router.post("/teams", response_model=AgentTeamRead)
+def create_team(
+    payload: AgentTeamCreate,
+    session=Depends(get_session),
+    context=Depends(build_context),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = AgentBuilderService(session)
+    team = service.create_agent_team(payload.model_dump(), created_by=current_user.id)
+    members = service.list_team_members(team.id)
+    _refresh_registry(context, session)
+    data = team.model_dump()
+    data["members"] = [member.model_dump() for member in members]
+    return AgentTeamRead.model_validate(data)
+
+
+@router.patch("/teams/{team_id}", response_model=AgentTeamRead)
+def update_team(
+    team_id: int,
+    payload: AgentTeamUpdate,
+    session=Depends(get_session),
+    context=Depends(build_context),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = AgentBuilderService(session)
+    team = service.update_agent_team(team_id, payload.model_dump(exclude_unset=True))
+    members = service.list_team_members(team.id)
+    _refresh_registry(context, session)
+    data = team.model_dump()
+    data["members"] = [member.model_dump() for member in members]
+    return AgentTeamRead.model_validate(data)
+
+
+@router.get("/validator", response_model=List[ValidatorProfileRead])
+def list_validator_profiles(session=Depends(get_session), current_user: User = Depends(get_current_active_user)):
+    service = AgentBuilderService(session)
+    return [ValidatorProfileRead.model_validate(v) for v in service.list_validators()]
+
+
+@router.post("/validator", response_model=ValidatorProfileRead)
+def upsert_validator(
+    payload: ValidatorProfileCreate,
+    session=Depends(get_session),
+    context=Depends(build_context),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = AgentBuilderService(session)
+    validator = service.upsert_validator(payload.model_dump(), created_by=current_user.id)
+    _refresh_registry(context, session)
+    return ValidatorProfileRead.model_validate(validator)
+
+
+@router.get("/snapshot", response_model=RegistrySnapshotRead)
+def get_registry_snapshot(session=Depends(get_session), context=Depends(build_context), current_user: User = Depends(get_current_active_user)):
+    snapshot = AgentRegistryLoader(session, context.settings).build_snapshot()
+    registry_data = dict(context.settings.model_registry)
+    registry_data.update(snapshot.registry)
+    return RegistrySnapshotRead(
+        registry=registry_data,
+        knowledge_bases=snapshot.knowledge_bases,
+        teams=snapshot.teams,
+        tools=snapshot.tools,
+        validator=snapshot.validator,
+        orchestrator_agent=snapshot.orchestrator_agent,
+    )

--- a/worker/tigerchain_app/agents/schemas.py
+++ b/worker/tigerchain_app/agents/schemas.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+"""Pydantic schemas for the agent builder API."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class KnowledgeBaseCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+    tags: List[str] = Field(default_factory=list)
+    document_ids: List[str] = Field(default_factory=list)
+    metadata: dict = Field(default_factory=dict)
+
+
+class KnowledgeBaseUpdate(BaseModel):
+    description: Optional[str] = None
+    tags: Optional[List[str]] = None
+    document_ids: Optional[List[str]] = None
+    metadata: Optional[dict] = None
+
+
+class KnowledgeBaseRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: int
+    name: str
+    description: Optional[str]
+    tags: List[str]
+    document_ids: List[str]
+    metadata: dict = Field(default_factory=dict, alias="extra_metadata")
+
+
+class AgentProfileCreate(BaseModel):
+    name: str
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    role: Optional[str] = None
+    role_type: str = Field(default="chat")
+    system_prompt: Optional[str] = None
+    knowledge_base_id: Optional[int] = None
+    embedding_documents: List[str] = Field(default_factory=list)
+    metadata: dict = Field(default_factory=dict)
+    tags: List[str] = Field(default_factory=list)
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    temperature: Optional[float] = None
+    available_tools: List[str] = Field(default_factory=list)
+    requires_human_validation: bool = Field(default=True)
+    validator_instructions: Optional[str] = None
+
+
+class AgentProfileUpdate(BaseModel):
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    role: Optional[str] = None
+    role_type: Optional[str] = None
+    system_prompt: Optional[str] = None
+    knowledge_base_id: Optional[int] = None
+    embedding_documents: Optional[List[str]] = None
+    metadata: Optional[dict] = None
+    tags: Optional[List[str]] = None
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    temperature: Optional[float] = None
+    available_tools: Optional[List[str]] = None
+    requires_human_validation: Optional[bool] = None
+    validator_instructions: Optional[str] = None
+
+
+class AgentProfileRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: int
+    name: str
+    display_name: Optional[str]
+    description: Optional[str]
+    role: Optional[str]
+    role_type: str
+    system_prompt: Optional[str]
+    knowledge_base_id: Optional[int]
+    embedding_documents: List[str]
+    metadata: dict = Field(default_factory=dict, alias="extra_metadata")
+    tags: List[str]
+    provider: Optional[str]
+    model: Optional[str]
+    temperature: Optional[float]
+    available_tools: List[str]
+    requires_human_validation: bool
+    validator_instructions: Optional[str]
+
+
+class AgentTeamMemberCreate(BaseModel):
+    agent_id: int
+    priority: int = 0
+    responsibilities: List[str] = Field(default_factory=list)
+    metadata: dict = Field(default_factory=dict)
+
+
+class AgentTeamCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+    orchestrator_agent: Optional[str] = None
+    metadata: dict = Field(default_factory=dict)
+    tags: List[str] = Field(default_factory=list)
+    members: List[AgentTeamMemberCreate] = Field(default_factory=list)
+
+
+class AgentTeamUpdate(BaseModel):
+    description: Optional[str] = None
+    orchestrator_agent: Optional[str] = None
+    metadata: Optional[dict] = None
+    tags: Optional[List[str]] = None
+    members: Optional[List[AgentTeamMemberCreate]] = None
+
+
+class AgentTeamMemberRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: int
+    agent_id: int
+    priority: int
+    responsibilities: List[str]
+    metadata: dict = Field(default_factory=dict, alias="extra_metadata")
+
+
+class AgentTeamRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: int
+    name: str
+    description: Optional[str]
+    orchestrator_agent: Optional[str]
+    metadata: dict = Field(default_factory=dict, alias="extra_metadata")
+    tags: List[str]
+    members: List[AgentTeamMemberRead]
+
+
+class ToolTemplateCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+    specification: dict = Field(default_factory=dict)
+    tags: List[str] = Field(default_factory=list)
+    is_mcp: bool = True
+    metadata: dict = Field(default_factory=dict)
+
+
+class ToolTemplateRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: int
+    name: str
+    description: Optional[str]
+    specification: dict
+    tags: List[str]
+    is_mcp: bool
+    metadata: dict = Field(default_factory=dict, alias="extra_metadata")
+
+
+class ToolAssignmentRequest(BaseModel):
+    tool_id: int
+    scope: str = Field(default="global")
+    metadata: dict = Field(default_factory=dict)
+
+
+class ValidatorProfileCreate(BaseModel):
+    name: str
+    role_description: Optional[str] = None
+    contact: Optional[str] = None
+    instructions: Optional[str] = None
+    metadata: dict = Field(default_factory=dict)
+    is_active: bool = True
+
+
+class ValidatorProfileRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: int
+    name: str
+    role_description: Optional[str]
+    contact: Optional[str]
+    instructions: Optional[str]
+    metadata: dict = Field(default_factory=dict, alias="extra_metadata")
+    is_active: bool
+
+
+class RegistrySnapshotRead(BaseModel):
+    registry: Dict[str, Any]
+    knowledge_bases: List[Dict[str, Any]]
+    teams: List[Dict[str, Any]]
+    tools: List[Dict[str, Any]]
+    validator: Optional[Dict[str, Any]]
+    orchestrator_agent: Optional[str]

--- a/worker/tigerchain_app/agents/service.py
+++ b/worker/tigerchain_app/agents/service.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+"""Service layer for the agent builder endpoints."""
+
+from datetime import datetime
+from typing import Iterable, List
+
+from sqlmodel import Session, select
+
+from .models import (
+    AgentProfile,
+    AgentTeam,
+    AgentTeamMember,
+    AgentToolAssignment,
+    KnowledgeBase,
+    ToolTemplate,
+    ValidatorProfile,
+)
+
+
+def _now() -> datetime:
+    return datetime.utcnow()
+
+
+class AgentBuilderService:
+    """Encapsulates persistence logic for agent builder resources."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    @staticmethod
+    def _normalise_metadata(payload: dict) -> dict:
+        if "metadata" in payload and "extra_metadata" not in payload:
+            payload["extra_metadata"] = payload.pop("metadata")
+        return payload
+
+    # ------------------------------------------------------------------
+    # Knowledge bases
+    # ------------------------------------------------------------------
+    def create_knowledge_base(self, payload: dict, created_by: int | None) -> KnowledgeBase:
+        payload = self._normalise_metadata(dict(payload))
+        kb = KnowledgeBase(**payload, created_by=created_by)
+        self.session.add(kb)
+        self.session.commit()
+        self.session.refresh(kb)
+        return kb
+
+    def update_knowledge_base(self, kb_id: int, payload: dict) -> KnowledgeBase:
+        kb = self.session.get(KnowledgeBase, kb_id)
+        if kb is None:
+            raise ValueError(f"Knowledge base {kb_id} not found")
+        payload = self._normalise_metadata(dict(payload))
+        for key, value in payload.items():
+            if value is not None:
+                setattr(kb, key, value)
+        kb.updated_at = _now()
+        self.session.add(kb)
+        self.session.commit()
+        self.session.refresh(kb)
+        return kb
+
+    def list_knowledge_bases(self) -> List[KnowledgeBase]:
+        return self.session.exec(select(KnowledgeBase).order_by(KnowledgeBase.name)).all()
+
+    # ------------------------------------------------------------------
+    # Agent profiles
+    # ------------------------------------------------------------------
+    def create_agent_profile(self, payload: dict, created_by: int | None) -> AgentProfile:
+        payload = self._normalise_metadata(dict(payload))
+        profile = AgentProfile(**payload, created_by=created_by)
+        self.session.add(profile)
+        self.session.commit()
+        self.session.refresh(profile)
+        return profile
+
+    def update_agent_profile(self, agent_id: int, payload: dict) -> AgentProfile:
+        profile = self.session.get(AgentProfile, agent_id)
+        if profile is None:
+            raise ValueError(f"Agent profile {agent_id} not found")
+        payload = self._normalise_metadata(dict(payload))
+        for key, value in payload.items():
+            if value is not None:
+                setattr(profile, key, value)
+        profile.updated_at = _now()
+        self.session.add(profile)
+        self.session.commit()
+        self.session.refresh(profile)
+        return profile
+
+    def list_agent_profiles(self) -> List[AgentProfile]:
+        statement = select(AgentProfile).order_by(AgentProfile.name)
+        return self.session.exec(statement).all()
+
+    def get_agent_profile(self, agent_id: int) -> AgentProfile | None:
+        return self.session.get(AgentProfile, agent_id)
+
+    # ------------------------------------------------------------------
+    # Tools
+    # ------------------------------------------------------------------
+    def create_tool_template(self, payload: dict, created_by: int | None) -> ToolTemplate:
+        payload = self._normalise_metadata(dict(payload))
+        template = ToolTemplate(**payload, created_by=created_by)
+        self.session.add(template)
+        self.session.commit()
+        self.session.refresh(template)
+        return template
+
+    def list_tool_templates(self) -> List[ToolTemplate]:
+        return self.session.exec(select(ToolTemplate).order_by(ToolTemplate.name)).all()
+
+    def assign_tool_to_agent(self, agent_id: int, tool_id: int, payload: dict) -> AgentToolAssignment:
+        payload = self._normalise_metadata(dict(payload))
+        assignment = self.session.exec(
+            select(AgentToolAssignment).where(
+                AgentToolAssignment.agent_id == agent_id,
+                AgentToolAssignment.tool_id == tool_id,
+            )
+        ).first()
+        if assignment:
+            for key, value in payload.items():
+                if value is not None:
+                    setattr(assignment, key, value)
+            assignment.updated_at = _now()
+        else:
+            assignment = AgentToolAssignment(agent_id=agent_id, tool_id=tool_id, **payload)
+        self.session.add(assignment)
+        self.session.commit()
+        self.session.refresh(assignment)
+        return assignment
+
+    # ------------------------------------------------------------------
+    # Teams
+    # ------------------------------------------------------------------
+    def create_agent_team(self, payload: dict, created_by: int | None) -> AgentTeam:
+        members_payload = payload.pop("members", [])
+        payload = self._normalise_metadata(dict(payload))
+        team = AgentTeam(**payload, created_by=created_by)
+        self.session.add(team)
+        self.session.commit()
+        self.session.refresh(team)
+        self._sync_team_members(team, members_payload)
+        return team
+
+    def update_agent_team(self, team_id: int, payload: dict) -> AgentTeam:
+        team = self.session.get(AgentTeam, team_id)
+        if team is None:
+            raise ValueError(f"Agent team {team_id} not found")
+        members_payload = payload.pop("members", None)
+        payload = self._normalise_metadata(dict(payload))
+        for key, value in payload.items():
+            if value is not None:
+                setattr(team, key, value)
+        team.updated_at = _now()
+        self.session.add(team)
+        self.session.commit()
+        self.session.refresh(team)
+        if members_payload is not None:
+            self._sync_team_members(team, members_payload)
+        return team
+
+    def list_agent_teams(self) -> List[AgentTeam]:
+        return self.session.exec(select(AgentTeam).order_by(AgentTeam.name)).all()
+
+    def list_team_members(self, team_id: int) -> List[AgentTeamMember]:
+        statement = select(AgentTeamMember).where(AgentTeamMember.team_id == team_id).order_by(AgentTeamMember.priority)
+        return self.session.exec(statement).all()
+
+    def _sync_team_members(self, team: AgentTeam, members_payload: Iterable[dict]) -> None:
+        existing_members = {member.id: member for member in self.list_team_members(team.id)}
+        seen_ids: set[int] = set()
+        order = 0
+        for member_payload in members_payload:
+            member_payload = self._normalise_metadata(dict(member_payload))
+            member_id = member_payload.get("id")
+            if member_id and member_id in existing_members:
+                member = existing_members[member_id]
+                for key, value in member_payload.items():
+                    if key == "id":
+                        continue
+                    setattr(member, key, value)
+                member.priority = member_payload.get("priority", order)
+                member.updated_at = _now()
+                seen_ids.add(member_id)
+                self.session.add(member)
+            else:
+                payload = {key: value for key, value in member_payload.items() if key not in {"id", "priority"}}
+                priority = member_payload.get("priority", order)
+                member = AgentTeamMember(team_id=team.id, priority=priority, **payload)
+                self.session.add(member)
+            order += 1
+        for member_id, member in existing_members.items():
+            if member_id not in seen_ids and member_id is not None:
+                self.session.delete(member)
+        self.session.commit()
+
+    # ------------------------------------------------------------------
+    # Validator
+    # ------------------------------------------------------------------
+    def upsert_validator(self, payload: dict, created_by: int | None) -> ValidatorProfile:
+        payload = self._normalise_metadata(dict(payload))
+        validator = self.session.exec(select(ValidatorProfile).order_by(ValidatorProfile.updated_at.desc())).first()
+        if validator:
+            for key, value in payload.items():
+                setattr(validator, key, value)
+            validator.updated_at = _now()
+        else:
+            validator = ValidatorProfile(**payload, created_by=created_by)
+        self.session.add(validator)
+        self.session.commit()
+        self.session.refresh(validator)
+        return validator
+
+    def list_validators(self) -> List[ValidatorProfile]:
+        return self.session.exec(select(ValidatorProfile).order_by(ValidatorProfile.updated_at.desc())).all()

--- a/worker/tigerchain_app/agents/templates/agent_builder.html
+++ b/worker/tigerchain_app/agents/templates/agent_builder.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>TigerChain Agent Builder</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 0;
+        padding: 0;
+        background: #0f172a;
+        color: #f8fafc;
+      }
+      header {
+        background: linear-gradient(135deg, #1d4ed8, #22d3ee);
+        padding: 24px 32px;
+      }
+      header h1 {
+        margin: 0;
+        font-size: 28px;
+      }
+      main {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        gap: 24px;
+        padding: 32px;
+      }
+      section {
+        background: rgba(15, 23, 42, 0.85);
+        border-radius: 16px;
+        box-shadow: 0 20px 40px rgba(15, 23, 42, 0.4);
+        padding: 24px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+      }
+      h2 {
+        margin-top: 0;
+        font-size: 20px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+        padding-bottom: 12px;
+      }
+      label {
+        display: block;
+        margin-top: 12px;
+        font-size: 14px;
+        font-weight: bold;
+        color: #cbd5f5;
+      }
+      input,
+      textarea,
+      select {
+        width: 100%;
+        padding: 10px;
+        margin-top: 6px;
+        border-radius: 8px;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        background: rgba(15, 23, 42, 0.9);
+        color: #f8fafc;
+      }
+      textarea {
+        min-height: 80px;
+      }
+      button {
+        margin-top: 16px;
+        padding: 12px 20px;
+        border: none;
+        border-radius: 10px;
+        background: linear-gradient(135deg, #2563eb, #22d3ee);
+        color: #0f172a;
+        font-weight: bold;
+        cursor: pointer;
+        transition: transform 0.2s ease;
+      }
+      button:hover {
+        transform: translateY(-2px);
+      }
+      .list {
+        margin-top: 16px;
+        max-height: 220px;
+        overflow-y: auto;
+        background: rgba(30, 41, 59, 0.6);
+        border-radius: 12px;
+        padding: 12px;
+      }
+      .list-item {
+        border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+        padding: 8px 0;
+      }
+      .list-item:last-child {
+        border-bottom: none;
+      }
+      .status {
+        margin-top: 12px;
+        font-size: 14px;
+        color: #38bdf8;
+      }
+      .tag {
+        display: inline-block;
+        padding: 4px 8px;
+        border-radius: 9999px;
+        background: rgba(96, 165, 250, 0.2);
+        margin-right: 6px;
+        font-size: 12px;
+      }
+      @media (max-width: 768px) {
+        main {
+          grid-template-columns: 1fr;
+          padding: 16px;
+        }
+        section {
+          padding: 18px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>TigerChain Agent Builder</h1>
+      <p>Create role-based agents, associate knowledge bases, and curate tool inventories with human validation flows.</p>
+    </header>
+    <main>
+      <section>
+        <h2>Knowledge Bases</h2>
+        <label for="kb-name">Name</label>
+        <input id="kb-name" placeholder="e.g. Product Architecture" />
+        <label for="kb-tags">Tags (comma separated)</label>
+        <input id="kb-tags" placeholder="architecture, roadmap" />
+        <label for="kb-docs">Document IDs (comma separated)</label>
+        <input id="kb-docs" placeholder="doc::alpha, doc::beta" />
+        <label for="kb-description">Description</label>
+        <textarea id="kb-description" placeholder="Focus area for this knowledge base"></textarea>
+        <button onclick="createKnowledgeBase()">Create Knowledge Base</button>
+        <div class="status" id="kb-status"></div>
+        <div class="list" id="kb-list"></div>
+      </section>
+
+      <section>
+        <h2>Agent Profiles</h2>
+        <label for="agent-name">Name</label>
+        <input id="agent-name" placeholder="e.g. architecture_planner" />
+        <label for="agent-role">Role Type</label>
+        <select id="agent-role">
+          <option value="chat">Chat Specialist</option>
+          <option value="team_member">Team Member</option>
+          <option value="orchestrator">Orchestrator</option>
+        </select>
+        <label for="agent-description">Description</label>
+        <textarea id="agent-description" placeholder="Describe responsibilities"></textarea>
+        <label for="agent-knowledge">Knowledge Base ID</label>
+        <input id="agent-knowledge" placeholder="Numeric knowledge base id" />
+        <label for="agent-tags">Tags</label>
+        <input id="agent-tags" placeholder="governance, infra" />
+        <label for="agent-validation">Requires Human Validation</label>
+        <select id="agent-validation">
+          <option value="true">Yes</option>
+          <option value="false">No</option>
+        </select>
+        <button onclick="createAgent()">Create Agent</button>
+        <div class="status" id="agent-status"></div>
+        <div class="list" id="agent-list"></div>
+      </section>
+
+      <section>
+        <h2>Teams & Validator</h2>
+        <label for="team-name">Team Name</label>
+        <input id="team-name" placeholder="Discovery Squad" />
+        <label for="team-orchestrator">Orchestrator Agent</label>
+        <input id="team-orchestrator" placeholder="orchestrator alias" />
+        <label for="team-members">Members (agent_id:priority)</label>
+        <input id="team-members" placeholder="1:0,2:1" />
+        <button onclick="createTeam()">Create Team</button>
+        <div class="status" id="team-status"></div>
+        <div class="list" id="team-list"></div>
+        <hr />
+        <label for="validator-name">Validator Name</label>
+        <input id="validator-name" placeholder="Program Manager" />
+        <label for="validator-contact">Contact Info</label>
+        <input id="validator-contact" placeholder="ops@example.com" />
+        <label for="validator-instructions">Instructions</label>
+        <textarea id="validator-instructions" placeholder="Escalate blockers and confirm delivery priority"></textarea>
+        <button onclick="setValidator()">Save Validator</button>
+        <div class="status" id="validator-status"></div>
+      </section>
+    </main>
+
+    <script>
+      const tokenKey = "tigerchain_token";
+
+      async function apiRequest(path, method = "GET", body) {
+        const token = localStorage.getItem(tokenKey) || "";
+        const headers = { "Content-Type": "application/json" };
+        if (token) {
+          headers["Authorization"] = `Bearer ${token}`;
+        }
+        const response = await fetch(path, {
+          method,
+          headers,
+          body: body ? JSON.stringify(body) : undefined,
+        });
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(errorText || response.statusText);
+        }
+        return response.json();
+      }
+
+      async function refreshSnapshot() {
+        try {
+          const data = await apiRequest("/builder/snapshot");
+          renderKnowledgeBases(data.knowledge_bases);
+          renderAgents(Object.entries(data.registry));
+          renderTeams(data.teams);
+        } catch (err) {
+          console.error(err);
+        }
+      }
+
+      function renderKnowledgeBases(items) {
+        const container = document.getElementById("kb-list");
+        container.innerHTML = items
+          .map(
+            (kb) => `
+          <div class="list-item">
+            <strong>${kb.name}</strong> (ID: ${kb.id || "pending"})<br />
+            <small>${kb.description || "No description"}</small><br />
+            ${kb.tags.map((tag) => `<span class="tag">${tag}</span>`).join(" ")}
+          </div>`
+          )
+          .join("") || "<p>No knowledge bases yet.</p>";
+      }
+
+      function renderAgents(entries) {
+        const container = document.getElementById("agent-list");
+        container.innerHTML = entries
+          .map(([name, config]) => `
+          <div class="list-item">
+            <strong>${name}</strong> <span class="tag">${config.role_type || "chat"}</span><br />
+            <small>${config.role || "No role description"}</small><br />
+            ${Array.isArray(config.tags) ? config.tags.map((tag) => `<span class="tag">${tag}</span>`).join(" ") : ""}
+          </div>`
+          )
+          .join("") || "<p>No agents configured.</p>";
+      }
+
+      function renderTeams(items) {
+        const container = document.getElementById("team-list");
+        container.innerHTML = items
+          .map(
+            (team) => `
+          <div class="list-item">
+            <strong>${team.name}</strong> (Orchestrator: ${team.orchestrator_agent || "default"})<br />
+            <small>${team.description || "No description"}</small><br />
+            Members: ${
+              team.members && team.members.length
+                ? team.members.map((m) => `${m.agent_id} (p${m.priority})`).join(", ")
+                : "None"
+            }
+          </div>`
+          )
+          .join("") || "<p>No teams yet.</p>";
+      }
+
+      async function createKnowledgeBase() {
+        const name = document.getElementById("kb-name").value.trim();
+        if (!name) {
+          return;
+        }
+        const payload = {
+          name,
+          tags: document.getElementById("kb-tags").value.split(",").map((t) => t.trim()).filter(Boolean),
+          document_ids: document.getElementById("kb-docs").value.split(",").map((t) => t.trim()).filter(Boolean),
+          description: document.getElementById("kb-description").value,
+        };
+        try {
+          await apiRequest("/builder/knowledge-bases", "POST", payload);
+          document.getElementById("kb-status").innerText = "Knowledge base created.";
+          refreshSnapshot();
+        } catch (err) {
+          document.getElementById("kb-status").innerText = `Error: ${err.message}`;
+        }
+      }
+
+      async function createAgent() {
+        const name = document.getElementById("agent-name").value.trim();
+        if (!name) {
+          return;
+        }
+        const payload = {
+          name,
+          role_type: document.getElementById("agent-role").value,
+          description: document.getElementById("agent-description").value,
+          knowledge_base_id: parseInt(document.getElementById("agent-knowledge").value || "0", 10) || null,
+          tags: document.getElementById("agent-tags").value.split(",").map((t) => t.trim()).filter(Boolean),
+          requires_human_validation: document.getElementById("agent-validation").value === "true",
+        };
+        try {
+          await apiRequest("/builder/agents", "POST", payload);
+          document.getElementById("agent-status").innerText = "Agent created.";
+          refreshSnapshot();
+        } catch (err) {
+          document.getElementById("agent-status").innerText = `Error: ${err.message}`;
+        }
+      }
+
+      async function createTeam() {
+        const name = document.getElementById("team-name").value.trim();
+        if (!name) {
+          return;
+        }
+        const members = document
+          .getElementById("team-members")
+          .value.split(",")
+          .map((pair) => pair.trim())
+          .filter(Boolean)
+          .map((pair) => {
+            const [agentId, priority] = pair.split(":");
+            return {
+              agent_id: parseInt(agentId, 10),
+              priority: priority ? parseInt(priority, 10) : 0,
+            };
+          });
+        const payload = {
+          name,
+          orchestrator_agent: document.getElementById("team-orchestrator").value || null,
+          members,
+        };
+        try {
+          await apiRequest("/builder/teams", "POST", payload);
+          document.getElementById("team-status").innerText = "Team saved.";
+          refreshSnapshot();
+        } catch (err) {
+          document.getElementById("team-status").innerText = `Error: ${err.message}`;
+        }
+      }
+
+      async function setValidator() {
+        const name = document.getElementById("validator-name").value.trim();
+        if (!name) {
+          return;
+        }
+        const payload = {
+          name,
+          contact: document.getElementById("validator-contact").value,
+          instructions: document.getElementById("validator-instructions").value,
+        };
+        try {
+          await apiRequest("/builder/validator", "POST", payload);
+          document.getElementById("validator-status").innerText = "Validator updated.";
+          refreshSnapshot();
+        } catch (err) {
+          document.getElementById("validator-status").innerText = `Error: ${err.message}`;
+        }
+      }
+
+      refreshSnapshot();
+    </script>
+  </body>
+</html>

--- a/worker/tigerchain_app/context.py
+++ b/worker/tigerchain_app/context.py
@@ -8,8 +8,10 @@ from langchain_core.embeddings import Embeddings
 from langchain_core.language_models import BaseLanguageModel
 
 from .agents import AgentOrchestrator
+from .agents import models as _agent_models  # noqa: F401 - ensure models registered
+from .agents.registry import AgentRegistryLoader, AgentRegistrySnapshot
 from .auth import models as _auth_models  # noqa: F401 - ensure models registered
-from .auth.database import init_db
+from .auth.database import init_db, session_scope
 from .config import Settings, get_settings
 from .ingestion.embeddings import create_embeddings
 from .ingestion.pipeline import DocumentIngestionPipeline
@@ -46,6 +48,16 @@ def build_context(force: bool = False) -> ApplicationContext:
 
     settings = get_settings()
     init_db(settings)
+    base_registry = dict(settings.model_registry)
+    registry_snapshot = AgentRegistrySnapshot()
+    with session_scope(settings) as session:
+        loader = AgentRegistryLoader(session, settings)
+        registry_snapshot = loader.build_snapshot()
+    if registry_snapshot.registry:
+        combined_registry = dict(base_registry)
+        combined_registry.update(registry_snapshot.registry)
+        settings.model_registry = combined_registry
+
     embeddings = create_embeddings(settings)
     tigergraph = TigerGraphClient(settings)
     _bootstrap_gsql(tigergraph)
@@ -54,7 +66,13 @@ def build_context(force: bool = False) -> ApplicationContext:
     retriever = TigerGraphVectorRetriever(settings, embeddings, tigergraph)
     llm = create_llm(settings)
     qa_chain = build_qa_chain(settings, retriever, llm)
-    agent_orchestrator = AgentOrchestrator(settings, embeddings, tigergraph)
+    agent_orchestrator = AgentOrchestrator(
+        settings,
+        embeddings,
+        tigergraph,
+        base_registry=base_registry,
+        snapshot=registry_snapshot,
+    )
 
     _context = ApplicationContext(
         settings=settings,


### PR DESCRIPTION
## Summary
- add persistent SQLModel tables, schemas, and service logic to capture knowledge bases, agents, teams, tools, and validators for the RAG agent builder
- expose a FastAPI builder router and lightweight UI so operators can curate agents, assign tool inventories, and refresh orchestrator state dynamically
- extend application context and orchestrator metadata handling to merge dynamic agent registries and surface human validation concerns in query responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5516131e0832595e4acae1cf3d2e3