### PR TITLE
Enhance retrieval quality with reranking and subject routing

### DIFF
--- a/worker/tests/test_ingestion_pipeline.py
+++ b/worker/tests/test_ingestion_pipeline.py
@@ -140,6 +140,11 @@ def test_ingest_files_populates_metadata(tmp_path: Path, pipeline: DocumentInges
     assert row.metadata["source_file_size"] == source.stat().st_size
     assert result.documents[0].source_checksum == row.metadata["source_checksum"]
     assert result.documents[0].file_size_bytes == source.stat().st_size
+    assert row.metadata.get("subject_tags")
+    assert "importance_score" in row.metadata
+    document_metadata = result.documents[0].metadata
+    assert document_metadata.get("subject_tags")
+    assert document_metadata.get("importance_score") is not None
 
     store: DummyObjectStore = pipeline.object_store  # type: ignore[attr-defined]
     assert store.uploaded_json, "private embeddings should be persisted in 'both' scope"

--- a/worker/tests/test_orchestrator.py
+++ b/worker/tests/test_orchestrator.py
@@ -1,0 +1,83 @@
+import asyncio
+import sys
+import types
+from typing import Dict
+
+import pytest
+
+if "langchain.chains" not in sys.modules:
+    chains_module = types.ModuleType("langchain.chains")
+
+    class _RetrievalQA:  # pragma: no cover - minimal async stub
+        async def ainvoke(self, _: dict) -> dict:
+            return {}
+
+    chains_module.RetrievalQA = _RetrievalQA  # type: ignore[attr-defined]
+    sys.modules[chains_module.__name__] = chains_module
+
+if "langchain_core.embeddings" not in sys.modules:
+    embeddings_module = types.ModuleType("langchain_core.embeddings")
+
+    class _Embeddings:  # pragma: no cover - runtime stub
+        ...
+
+    embeddings_module.Embeddings = _Embeddings  # type: ignore[attr-defined]
+    sys.modules[embeddings_module.__name__] = embeddings_module
+
+if "pyTigerGraph" not in sys.modules:
+    tigergraph_module = types.ModuleType("pyTigerGraph")
+    tigergraph_module.TigerGraphConnection = object  # type: ignore[attr-defined]
+    sys.modules[tigergraph_module.__name__] = tigergraph_module
+
+if "langchain_openai" not in sys.modules:
+    openai_module = types.ModuleType("langchain_openai")
+
+    class _ChatOpenAI:  # pragma: no cover - runtime stub
+        ...
+
+    openai_module.ChatOpenAI = _ChatOpenAI  # type: ignore[attr-defined]
+    sys.modules[openai_module.__name__] = openai_module
+
+from tigerchain_app.agents.orchestrator import AgentOrchestrator, AgentQueryResult, QueryContext
+from tigerchain_app.config import Settings
+
+
+class _StubAgent:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.contexts: list[QueryContext] = []
+
+    async def arun(self, question: str, context: QueryContext) -> AgentQueryResult:
+        self.contexts.append(context)
+        return AgentQueryResult(agent=self.name, answer=f"{self.name}:{question}", sources=[])
+
+
+class _DummyEmbeddings:
+    pass
+
+
+class _DummyTigerGraphClient:
+    pass
+
+
+def test_orchestrator_prioritises_subject_alignment(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = Settings()
+    settings.model_registry = {
+        "alpha": {"subject_specialities": ["compliance"]},
+        "beta": {"subject_specialities": ["product"]},
+    }
+    orchestrator = AgentOrchestrator(settings, _DummyEmbeddings(), _DummyTigerGraphClient())
+
+    stubs: Dict[str, _StubAgent] = {name: _StubAgent(name) for name in settings.model_registry}
+    monkeypatch.setattr(orchestrator, "_get_agent", lambda name: stubs[name])
+
+    context = QueryContext(subject_priorities={"compliance": 0.9, "product": 0.4})
+    results = asyncio.run(
+        orchestrator.run_query(
+            "How to comply?", agent_names=["beta", "alpha"], query_context=context, mode="parallel"
+        )
+    )
+
+    assert [result.agent for result in results][:2] == ["alpha", "beta"]
+    assert all(ctx.model_alias is None for ctx in stubs["alpha"].contexts)
+    assert all(ctx.model_alias is None for ctx in stubs["beta"].contexts)

--- a/worker/tigerchain_app/config.py
+++ b/worker/tigerchain_app/config.py
@@ -67,6 +67,13 @@ class Settings(BaseSettings):
 
     # Retrieval
     top_k: int = Field(default=5, description="Number of similar chunks to fetch per query")
+    retrieval_overfetch_factor: float = Field(
+        default=2.5,
+        description=(
+            "Multiplier applied to top_k when fetching raw candidates from the vector store. "
+            "The additional documents are later filtered and reranked to compensate for metadata filters."
+        ),
+    )
 
     # LLM providers
     llm_provider: Literal["ollama", "vllm", "openai", "anthropic"] = Field(default="ollama", description="LLM backend provider")

--- a/worker/tigerchain_app/utils/importance.py
+++ b/worker/tigerchain_app/utils/importance.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+
+class DocumentImportanceScorer:
+    """Heuristically scores documents and chunks to support reranking."""
+
+    def __init__(
+        self,
+        *,
+        base_score: float = 0.45,
+        size_weight: float = 0.25,
+        category_weight: float = 0.15,
+        subject_weight: float = 0.15,
+    ) -> None:
+        self.base_score = base_score
+        self.size_weight = size_weight
+        self.category_weight = category_weight
+        self.subject_weight = subject_weight
+
+    def score_document(
+        self,
+        *,
+        file_size_bytes: int,
+        categories: Iterable[str],
+        metadata: Dict[str, object] | None,
+        subject_tags: Iterable[str],
+    ) -> float:
+        score = self.base_score
+        size_factor = min(file_size_bytes / 1_000_000, 1.0)
+        score += size_factor * self.size_weight
+
+        normalised_categories = {str(cat).strip().lower() for cat in categories if str(cat).strip()}
+        if normalised_categories & {"policy", "legal", "compliance"}:
+            score += self.category_weight
+        elif normalised_categories:
+            score += self.category_weight * 0.5
+
+        subject_set = {tag.strip().lower() for tag in subject_tags if tag}
+        if subject_set & {"compliance", "security"}:
+            score += self.subject_weight
+        elif subject_set & {"product", "engineering"}:
+            score += self.subject_weight * 0.7
+        elif subject_set:
+            score += self.subject_weight * 0.4
+
+        priority_hint = None
+        if metadata:
+            priority_hint = metadata.get("priority") or metadata.get("importance")
+        if isinstance(priority_hint, str):
+            value = priority_hint.strip().lower()
+            if value in {"critical", "high"}:
+                score += 0.2
+            elif value in {"medium", "default"}:
+                score += 0.1
+        elif isinstance(priority_hint, (int, float)):
+            score += min(max(float(priority_hint), 0.0), 1.0) * 0.2
+
+        return round(max(0.0, min(score, 1.0)), 3)
+
+    def score_chunk(
+        self,
+        *,
+        chunk_length: int,
+        document_score: float,
+        subject_tags: Iterable[str],
+    ) -> float:
+        density = min(chunk_length / 900, 1.0)
+        subject_set = {tag.strip().lower() for tag in subject_tags if tag}
+        subject_boost = 0.15 if subject_set & {"compliance", "security"} else 0.0
+        score = (document_score * 0.6) + (density * 0.25) + subject_boost
+        return round(max(0.0, min(score, 1.0)), 3)
+
+    def rank_subjects(self, subject_tags: Iterable[str], document_score: float) -> Dict[str, float]:
+        weights: Dict[str, float] = {}
+        for index, tag in enumerate(sorted({tag.strip().lower() for tag in subject_tags if tag})):
+            decay = max(0.35, 1.0 - (index * 0.2))
+            weights[tag] = round(document_score * decay, 3)
+        return weights
+
+
+__all__ = ["DocumentImportanceScorer"]

--- a/worker/tigerchain_app/utils/subjects.py
+++ b/worker/tigerchain_app/utils/subjects.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Dict, Iterable, List, Sequence, Set
+
+
+DEFAULT_SUBJECT_KEYWORDS: Dict[str, Sequence[str]] = {
+    "compliance": ("policy", "regulation", "gdpr", "sox", "hipaa", "compliance"),
+    "security": ("encryption", "vulnerability", "incident", "breach", "security"),
+    "product": ("roadmap", "feature", "release", "product"),
+    "engineering": ("architecture", "api", "deployment", "infrastructure", "design"),
+    "support": ("faq", "troubleshoot", "support", "issue", "ticket"),
+    "sales": ("prospect", "pipeline", "deal", "sales", "pricing"),
+    "people": ("hiring", "benefit", "culture", "people", "hr"),
+}
+
+
+class SubjectClassifier:
+    """Lightweight keyword classifier used for subject tagging and routing."""
+
+    def __init__(self, keyword_map: Dict[str, Sequence[str]] | None = None) -> None:
+        self.keyword_map = {
+            key.strip().lower(): tuple({kw.strip().lower() for kw in values if kw})
+            for key, values in (keyword_map or DEFAULT_SUBJECT_KEYWORDS).items()
+        }
+
+    def classify(self, text: str, existing_tags: Iterable[str] | None = None) -> List[str]:
+        text_lower = text.lower()
+        hits: Set[str] = set(tag.strip().lower() for tag in existing_tags or [] if tag)
+        for subject, keywords in self.keyword_map.items():
+            if any(keyword in text_lower for keyword in keywords):
+                hits.add(subject)
+        if not hits:
+            hits.add("general")
+        return sorted(hits)
+
+    def build_collections(self, tags: Iterable[str]) -> List[dict]:
+        normalised = [tag.strip().lower() for tag in tags if tag]
+        counts = Counter(normalised)
+        collections: List[dict] = []
+        for tag, count in counts.most_common():
+            collections.append(
+                {
+                    "name": tag,
+                    "display_name": tag.replace("_", " ").title(),
+                    "document_count": count,
+                }
+            )
+        return collections
+
+    def priorities_from_categories(self, categories: Iterable[str] | None) -> Dict[str, float]:
+        priorities: Dict[str, float] = {}
+        for category in categories or []:
+            if not isinstance(category, str):
+                continue
+            tag = category.strip().lower()
+            if not tag:
+                continue
+            priorities[tag] = max(priorities.get(tag, 0.0), 0.6)
+            for subject, keywords in self.keyword_map.items():
+                if tag in keywords:
+                    priorities[subject] = max(priorities.get(subject, 0.0), 0.8)
+        return {key: round(value, 3) for key, value in priorities.items()}
+
+
+__all__ = ["SubjectClassifier", "DEFAULT_SUBJECT_KEYWORDS"]


### PR DESCRIPTION
## Summary
- add configurable overfetching and embedding-based reranking that incorporate subject weights and importance scores in the TigerGraph retriever
- enrich ingestion with automatic subject classification, document importance scoring, and expose the new metadata through uploads and query context
- prioritize agents based on subject specialties and propagate subject-aware query context from the API, plus add regression tests for ingestion metadata and orchestrator routing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d59c3a9124832580693e6d16aca199