### PR TITLE
Add arXiv ingestion pipeline and API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,18 @@ the RAG system.
      -F "sharing_preference=both"
    ```
 
+   You can also ingest arXiv papers directly by supplying an identifier or URL.
+   The service downloads the PDF, captures metadata (title, authors, abstract,
+   categories), chunks and embeds the content, and stores the result in
+   TigerGraph:
+
+   ```bash
+   curl -X POST "http://localhost:${API_PORT:-8000}/ingest/arxiv" \
+     -H "Authorization: Bearer ${TOKEN}" \
+     -H "Content-Type: application/json" \
+     -d '{"identifier":"2301.12345v1","categories":["research"],"model_alias":"default"}'
+   ```
+
 5. **Ask questions against the knowledge base** using sequential or parallel
    agent execution modes:
 
@@ -198,6 +210,20 @@ can build audit trails or user-facing dashboards.
 
 The `rag-api` container image bundles a Typer CLI for local operations. Use
 `docker compose run --rm rag-api python cli.py --help` for full details.
+
+### Ingesting arXiv papers from the CLI
+
+Download and ingest an arXiv paper in a single step:
+
+```bash
+python cli.py ingest-arxiv 2301.12345v1 --category research --agent default
+```
+
+The command accepts either a bare identifier (with or without a version), a
+full `https://arxiv.org/abs/...` URL, or a direct PDF link. The CLI mirrors the
+API behaviour by enriching chunk metadata with the arXiv title, authors,
+abstract, categories, and canonical URLs before persisting embeddings and
+source artefacts.
 
 - `make ingest` – embed and upsert all files under `worker/sample_docs` (supports `--owner`, `--agent`, and `--category`).
 - `make query Q="..."` – run an ad-hoc question against TigerGraph-stored data with optional `--agent`, `--mode`, and `--category` filters.

--- a/worker/cli.py
+++ b/worker/cli.py
@@ -10,6 +10,7 @@ import typer
 
 from tigerchain_app.agents import QueryContext
 from tigerchain_app.context import build_context
+from tigerchain_app.ingestion.pipeline import IngestionResult
 from tigerchain_app.utils.logging import configure_logging, get_logger
 
 app = typer.Typer(help="TigerChain CLI utilities")
@@ -35,6 +36,25 @@ def _format_bytes(size: int) -> str:
     return f"{value:.1f} PB"
 
 
+def _print_ingestion_summary(result: IngestionResult) -> None:
+    typer.echo(f"Ingested {len(result.chunks)} chunks from {len(result.documents)} document(s)")
+    if not result.documents:
+        return
+    typer.echo("\nIngestion summary:")
+    chunk_counts = Counter(row.doc_id for row in result.chunks)
+    for summary in result.documents:
+        chunk_total = chunk_counts.get(summary.doc_id, 0)
+        typer.echo(
+            f"- {summary.doc_id} · {summary.source_path.name} · {chunk_total} chunk(s) · "
+            f"{_format_bytes(summary.file_size_bytes)} · scope={summary.embedding_scope}"
+        )
+        if summary.categories:
+            typer.echo(f"  Categories: {', '.join(summary.categories)}")
+        typer.echo(f"  Object URI: {summary.uri}")
+        if summary.private_embedding_uri:
+            typer.echo(f"  Private embeddings: {summary.private_embedding_uri}")
+
+
 @app.command()
 def ingest(
     path: Path = typer.Argument(..., exists=True, help="Path to a document file or directory"),
@@ -54,21 +74,35 @@ def ingest(
     else:
         logger.info("Ingesting file %s", path)
         result = pipeline.ingest_files([path], owner_id=owner, categories=category, model_alias=agent)
-    typer.echo(f"Ingested {len(result.chunks)} chunks from {len(result.documents)} document(s)")
-    if result.documents:
-        typer.echo("\nIngestion summary:")
-        chunk_counts = Counter(row.doc_id for row in result.chunks)
-        for summary in result.documents:
-            chunk_total = chunk_counts.get(summary.doc_id, 0)
-            typer.echo(
-                f"- {summary.doc_id} · {summary.source_path.name} · {chunk_total} chunk(s) · "
-                f"{_format_bytes(summary.file_size_bytes)} · scope={summary.embedding_scope}"
-            )
-            if summary.categories:
-                typer.echo(f"  Categories: {', '.join(summary.categories)}")
-            typer.echo(f"  Object URI: {summary.uri}")
-            if summary.private_embedding_uri:
-                typer.echo(f"  Private embeddings: {summary.private_embedding_uri}")
+    _print_ingestion_summary(result)
+
+
+@app.command("ingest-arxiv")
+def ingest_arxiv(
+    identifier: str = typer.Argument(..., help="arXiv identifier or URL to ingest"),
+    owner: Optional[str] = typer.Option(None, "--owner", help="Optional owner identifier to scope the document"),
+    category: List[str] = typer.Option([], "--category", help="Additional categories to associate with the document"),
+    agent: Optional[str] = typer.Option(None, "--agent", help="Agent/model alias to tag the ingestion with"),
+    embedding_scope: str = typer.Option(
+        "both",
+        "--embedding-scope",
+        help="Embedding visibility scope: public, private, or both",
+    ),
+) -> None:
+    """Download and ingest an arXiv paper by identifier or URL."""
+
+    configure_logging()
+    context = build_context(force=True)
+    pipeline = context.pipeline
+
+    result = pipeline.ingest_arxiv(
+        identifier,
+        owner_id=owner,
+        categories=category,
+        model_alias=agent,
+        embedding_scope=embedding_scope,
+    )
+    _print_ingestion_summary(result)
 
 
 @app.command()

--- a/worker/server.py
+++ b/worker/server.py
@@ -20,6 +20,7 @@ from tigerchain_app.auth.schemas import DocumentRecord
 from tigerchain_app.auth.security import get_current_active_user
 from tigerchain_app.auth.service import DocumentService
 from tigerchain_app.context import build_context
+from tigerchain_app.ingestion.pipeline import IngestionResult
 from tigerchain_app.utils.logging import configure_logging, get_logger
 from tigerchain_app.utils.subjects import SubjectClassifier
 
@@ -77,6 +78,78 @@ class IngestResponse(BaseModel):
     ingested_chunks: int
     documents: List[IngestedDocumentResponse]
     agent: str
+
+
+class ArxivIngestRequest(BaseModel):
+    identifier: str
+    category: Optional[str] = None
+    categories: Optional[List[str]] = None
+    model_alias: Optional[str] = None
+    metadata: Optional[dict] = None
+    embedding_scope: Literal["public", "private", "both"] = "both"
+    sharing_preference: Literal["public", "private", "both"] = "both"
+    submission_id: Optional[str] = None
+
+
+def _select_agent_alias(context, current_user: User, model_alias: Optional[str]) -> str:
+    orchestrator = context.agent_orchestrator
+    available_agents = set(orchestrator.available_agents())
+    preferred_agent = model_alias or current_user.preferred_agent or context.settings.default_agent
+    if preferred_agent not in available_agents:
+        raise HTTPException(status_code=400, detail=f"Unknown agent '{preferred_agent}'")
+    return preferred_agent
+
+
+def _merge_categories(current_user: User, category: Optional[str], categories: Optional[List[str]]) -> set[str]:
+    category_values = set(current_user.categories or [])
+    if category:
+        category_values.add(category)
+    if categories:
+        category_values.update({value for value in categories if value})
+    return {value for value in category_values if value}
+
+
+def _persist_ingestion_records(
+    ingestion_result: IngestionResult,
+    *,
+    document_service: DocumentService,
+    current_user: User,
+    sharing_preference: str,
+) -> List[IngestedDocumentResponse]:
+    response_docs: List[IngestedDocumentResponse] = []
+    for summary in ingestion_result.documents:
+        record = document_service.record_upload(
+            user_id=current_user.id,
+            doc_id=summary.doc_id,
+            filename=summary.source_path.name,
+            categories=summary.categories,
+            model_alias=summary.model_alias,
+            object_uri=summary.uri,
+            http_url=summary.http_url,
+            metadata=summary.metadata,
+            submission_id=summary.submission_id,
+            embedding_scope=summary.embedding_scope,
+            sharing_preference=sharing_preference,
+            private_embedding_uri=summary.private_embedding_uri,
+        )
+        response_docs.append(
+            IngestedDocumentResponse(
+                doc_id=record.doc_id,
+                filename=record.filename,
+                categories=record.categories,
+                model_alias=record.model_alias,
+                object_uri=record.object_uri,
+                http_url=record.http_url,
+                metadata=record.metadata,
+                submission_id=record.submission_id or summary.submission_id,
+                private_embedding_uri=record.private_embedding_uri or summary.private_embedding_uri,
+                embedding_scope=record.embedding_scope or summary.embedding_scope,
+                sharing_preference=record.sharing_preference or sharing_preference,
+                file_size_bytes=summary.file_size_bytes,
+                source_checksum=summary.source_checksum,
+            )
+        )
+    return response_docs
 
 
 class AgentResult(BaseModel):
@@ -143,17 +216,8 @@ async def ingest_documents(
         paths.append(temp_path)
         logger.info("Uploaded %s (%s bytes)", upload.filename, temp_path.stat().st_size)
 
-    orchestrator = context.agent_orchestrator
-    available_agents = set(orchestrator.available_agents())
-    preferred_agent = model_alias or current_user.preferred_agent or context.settings.default_agent
-    if preferred_agent not in available_agents:
-        raise HTTPException(status_code=400, detail=f"Unknown agent '{preferred_agent}'")
-
-    category_values = set(current_user.categories or [])
-    if category:
-        category_values.add(category)
-    if categories:
-        category_values.update({value for value in categories if value})
+    preferred_agent = _select_agent_alias(context, current_user, model_alias)
+    category_values = _merge_categories(current_user, category, categories)
 
     ingestion_result = pipeline.ingest_files(
         paths,
@@ -166,39 +230,12 @@ async def ingest_documents(
     )
 
     document_service = DocumentService(session)
-    response_docs: List[IngestedDocumentResponse] = []
-    for summary in ingestion_result.documents:
-        record = document_service.record_upload(
-            user_id=current_user.id,
-            doc_id=summary.doc_id,
-            filename=summary.source_path.name,
-            categories=summary.categories,
-            model_alias=summary.model_alias,
-            object_uri=summary.uri,
-            http_url=summary.http_url,
-            metadata=summary.metadata,
-            submission_id=summary.submission_id,
-            embedding_scope=summary.embedding_scope,
-            sharing_preference=sharing_preference,
-            private_embedding_uri=summary.private_embedding_uri,
-        )
-        response_docs.append(
-            IngestedDocumentResponse(
-                doc_id=record.doc_id,
-                filename=record.filename,
-                categories=record.categories,
-                model_alias=record.model_alias,
-                object_uri=record.object_uri,
-                http_url=record.http_url,
-                metadata=record.metadata,
-                submission_id=record.submission_id or summary.submission_id,
-                private_embedding_uri=record.private_embedding_uri or summary.private_embedding_uri,
-                embedding_scope=record.embedding_scope or summary.embedding_scope,
-                sharing_preference=record.sharing_preference or sharing_preference,
-                file_size_bytes=summary.file_size_bytes,
-                source_checksum=summary.source_checksum,
-            )
-        )
+    response_docs = _persist_ingestion_records(
+        ingestion_result,
+        document_service=document_service,
+        current_user=current_user,
+        sharing_preference=sharing_preference,
+    )
 
     for path in paths:
         try:
@@ -206,6 +243,42 @@ async def ingest_documents(
         except Exception:
             logger.warning("Failed to remove temporary file %s", path)
     return IngestResponse(ingested_chunks=len(ingestion_result.chunks), documents=response_docs, agent=preferred_agent)
+
+
+@app.post("/ingest/arxiv", response_model=IngestResponse)
+async def ingest_arxiv_document(
+    request: ArxivIngestRequest,
+    context=Depends(get_context),
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_active_user),
+):
+    pipeline = context.pipeline
+    preferred_agent = _select_agent_alias(context, current_user, request.model_alias)
+    category_values = _merge_categories(current_user, request.category, request.categories)
+    extra_metadata = dict(request.metadata) if request.metadata else None
+
+    ingestion_result = pipeline.ingest_arxiv(
+        request.identifier,
+        owner_id=str(current_user.id),
+        categories=category_values,
+        model_alias=preferred_agent,
+        extra_metadata=extra_metadata,
+        embedding_scope=request.embedding_scope,
+        submission_id=request.submission_id,
+    )
+
+    document_service = DocumentService(session)
+    response_docs = _persist_ingestion_records(
+        ingestion_result,
+        document_service=document_service,
+        current_user=current_user,
+        sharing_preference=request.sharing_preference,
+    )
+    return IngestResponse(
+        ingested_chunks=len(ingestion_result.chunks),
+        documents=response_docs,
+        agent=preferred_agent,
+    )
 
 
 @app.post("/query", response_model=QueryResponse)

--- a/worker/tests/test_arxiv.py
+++ b/worker/tests/test_arxiv.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tigerchain_app.ingestion.arxiv import fetch_arxiv_paper, normalise_arxiv_id
+
+
+class DummyResponse:
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+
+    def raise_for_status(self) -> None:  # pragma: no cover - no-op for tests
+        return None
+
+
+class DummyStreamResponse(DummyResponse):
+    def __enter__(self) -> "DummyStreamResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # pragma: no cover - nothing to clean
+        return False
+
+    def iter_content(self, chunk_size: int):
+        yield self.content
+
+
+class DummySession:
+    def __init__(self, responses: list[DummyResponse]) -> None:
+        self._responses = responses
+        self.calls: list[tuple[str, dict]] = []
+
+    def get(self, url: str, **kwargs):
+        if not self._responses:
+            raise AssertionError("No more responses configured for DummySession")
+        response = self._responses.pop(0)
+        self.calls.append((url, kwargs))
+        return response
+
+
+def test_normalise_arxiv_id_variants() -> None:
+    assert normalise_arxiv_id("arXiv:2301.12345") == "2301.12345"
+    assert normalise_arxiv_id("https://arxiv.org/abs/2301.12345v2") == "2301.12345v2"
+    assert normalise_arxiv_id("https://arxiv.org/pdf/2301.12345.pdf") == "2301.12345"
+    assert normalise_arxiv_id("hep-th/9901001v1") == "hep-th/9901001v1"
+
+
+def test_fetch_arxiv_paper_parses_metadata(tmp_path: Path) -> None:
+    feed = b"""<?xml version='1.0' encoding='UTF-8'?>
+    <feed xmlns='http://www.w3.org/2005/Atom' xmlns:arxiv='http://arxiv.org/schemas/atom'>
+      <entry>
+        <id>http://arxiv.org/abs/2301.12345v1</id>
+        <updated>2023-01-10T12:34:56Z</updated>
+        <published>2023-01-09T12:00:00Z</published>
+        <title> Test Title </title>
+        <summary> Summary text </summary>
+        <author><name>Alice</name></author>
+        <author><name>Bob</name></author>
+        <link href='http://arxiv.org/pdf/2301.12345v1.pdf' type='application/pdf' rel='related'/>
+        <arxiv:doi>10.1000/test</arxiv:doi>
+        <arxiv:primary_category term='cs.AI'/>
+        <category term='cs.AI'/>
+        <category term='cs.LG'/>
+      </entry>
+    </feed>
+    """
+    pdf_bytes = b"%PDF-1.4 test"
+    session = DummySession([DummyResponse(feed), DummyStreamResponse(pdf_bytes)])
+
+    paper = fetch_arxiv_paper("https://arxiv.org/abs/2301.12345v1", session=session)
+    assert paper.arxiv_id == "2301.12345v1"
+    assert paper.title == "Test Title"
+    assert paper.authors == ["Alice", "Bob"]
+    assert paper.pdf_path.exists()
+    assert paper.pdf_path.read_bytes() == pdf_bytes
+    metadata = paper.to_ingestion_metadata()
+    assert metadata["abs_url"].endswith("2301.12345v1")
+    assert metadata["doi"] == "10.1000/test"
+    assert set(metadata["categories"]) == {"cs.AI", "cs.LG"}
+
+    paper.cleanup()
+    assert not paper.pdf_path.exists()
+
+    # ensure both metadata and PDF requests were issued
+    urls = [call[0] for call in session.calls]
+    assert any(url.endswith("api/query") for url in urls)
+    assert any(url.endswith("2301.12345v1.pdf") for url in urls)

--- a/worker/tests/test_ingestion_pipeline.py
+++ b/worker/tests/test_ingestion_pipeline.py
@@ -167,3 +167,51 @@ def test_invalid_scope_raises(tmp_path: Path, pipeline: DocumentIngestionPipelin
 
     with pytest.raises(ValueError):
         pipeline.ingest_files([source], embedding_scope="invalid-scope")
+
+
+def test_ingest_arxiv_uses_metadata(tmp_path: Path, pipeline: DocumentIngestionPipeline, monkeypatch: pytest.MonkeyPatch) -> None:
+    pdf_dir = tmp_path / "paper"
+    pdf_dir.mkdir()
+    pdf_path = pdf_dir / "2301.12345v1.pdf"
+    pdf_path.write_text("arxiv content")
+
+    from tigerchain_app.ingestion.arxiv import ArxivPaper
+
+    paper = ArxivPaper(
+        arxiv_id="2301.12345v1",
+        title="Sample Paper",
+        summary="Summary",
+        authors=["Alice"],
+        pdf_path=pdf_path,
+        pdf_url="https://arxiv.org/pdf/2301.12345v1.pdf",
+        abs_url="https://arxiv.org/abs/2301.12345v1",
+        published=None,
+        updated=None,
+        categories=["cs.AI"],
+        primary_category="cs.AI",
+        doi=None,
+        workdir=pdf_dir,
+    )
+
+    def _fake_fetch(identifier: str):
+        assert identifier == "2301.12345v1"
+        return paper
+
+    monkeypatch.setattr("tigerchain_app.ingestion.pipeline.fetch_arxiv_paper", _fake_fetch)
+
+    result = pipeline.ingest_arxiv(
+        "2301.12345v1",
+        owner_id="user-123",
+        categories=["custom"],
+        extra_metadata={"note": "value"},
+        embedding_scope=EmbeddingScope.BOTH,
+    )
+
+    assert result.documents, "expected arXiv ingestion to yield document summaries"
+    summary = result.documents[0]
+    assert "arxiv" in summary.metadata
+    assert summary.metadata["arxiv"]["id"] == "2301.12345v1"
+    assert summary.metadata["note"] == "value"
+    assert {c.lower() for c in summary.categories} >= {"custom", "cs.ai"}
+    assert result.chunks[0].metadata["ingestion_metadata"]["arxiv"]["id"] == "2301.12345v1"
+    assert not paper.pdf_path.exists(), "temporary arXiv PDF should be cleaned up"

--- a/worker/tigerchain_app/ingestion/arxiv.py
+++ b/worker/tigerchain_app/ingestion/arxiv.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import re
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+from xml.etree import ElementTree
+
+import requests
+
+from ..utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_ARXIV_ID_RE = re.compile(
+    r"^(?P<identifier>(?:arxiv:)?(?:(?:\d{4}\.\d{4,5})|(?:[a-z\-]+/\d{7}))(?P<version>v\d+)?)$",
+    re.IGNORECASE,
+)
+_ARXIV_URL_RE = re.compile(r"arxiv\.org/(?:abs|pdf)/([^/?#]+)", re.IGNORECASE)
+_ATOM_NS = "{http://www.w3.org/2005/Atom}"
+_ARXIV_NS = "{http://arxiv.org/schemas/atom}"
+_API_URL = "https://export.arxiv.org/api/query"
+_DEFAULT_USER_AGENT = "TigerChain-ArXivFetcher/1.0"
+
+
+@dataclass
+class ArxivPaper:
+    """Container describing a downloaded arXiv paper and its metadata."""
+
+    arxiv_id: str
+    title: str
+    summary: str
+    authors: list[str]
+    pdf_path: Path
+    pdf_url: str
+    abs_url: str
+    published: Optional[datetime]
+    updated: Optional[datetime]
+    categories: list[str] = field(default_factory=list)
+    primary_category: Optional[str] = None
+    doi: Optional[str] = None
+    workdir: Optional[Path] = field(default=None, repr=False)
+
+    def to_ingestion_metadata(self) -> dict[str, object]:
+        metadata: dict[str, object] = {
+            "id": self.arxiv_id,
+            "title": self.title,
+            "summary": self.summary,
+            "authors": list(self.authors),
+            "pdf_url": self.pdf_url,
+            "abs_url": self.abs_url,
+        }
+        if self.categories:
+            metadata["categories"] = list(self.categories)
+        if self.primary_category:
+            metadata["primary_category"] = self.primary_category
+        if self.published:
+            metadata["published"] = self.published.isoformat()
+        if self.updated:
+            metadata["updated"] = self.updated.isoformat()
+        if self.doi:
+            metadata["doi"] = self.doi
+        return metadata
+
+    def cleanup(self) -> None:
+        if self.workdir and self.workdir.exists():
+            shutil.rmtree(self.workdir, ignore_errors=True)
+            logger.debug("Removed temporary arXiv workdir %s", self.workdir)
+
+
+def normalise_arxiv_id(value: str) -> str:
+    """Extract the canonical arXiv identifier from common input formats."""
+
+    candidate = value.strip()
+    if not candidate:
+        raise ValueError("arXiv identifier or URL cannot be blank")
+
+    match = _ARXIV_URL_RE.search(candidate)
+    if match:
+        candidate = match.group(1)
+    candidate = candidate.split("?")[0].split("#")[0]
+    if candidate.lower().startswith("arxiv:"):
+        candidate = candidate.split(":", 1)[1]
+    if candidate.lower().endswith(".pdf"):
+        candidate = candidate[:-4]
+
+    candidate = candidate.strip()
+    regex_match = _ARXIV_ID_RE.match(candidate)
+    if not regex_match:
+        raise ValueError(f"Invalid arXiv identifier: {value}")
+
+    identifier = regex_match.group("identifier")
+    if identifier is None:
+        raise ValueError(f"Invalid arXiv identifier: {value}")
+    identifier = identifier.lower()
+    if identifier.startswith("arxiv:"):
+        identifier = identifier.split(":", 1)[1]
+    return identifier
+
+
+def fetch_arxiv_paper(identifier: str, *, session: Optional[requests.Session] = None) -> ArxivPaper:
+    """Fetch metadata and the PDF for the supplied arXiv identifier."""
+
+    arxiv_id = normalise_arxiv_id(identifier)
+    session = session or requests.Session()
+    headers = {"User-Agent": _DEFAULT_USER_AGENT}
+
+    logger.info("Fetching arXiv metadata for %s", arxiv_id)
+    response = session.get(
+        _API_URL,
+        params={"search_query": f"id:{arxiv_id}", "start": 0, "max_results": 1},
+        headers=headers,
+        timeout=30,
+    )
+    response.raise_for_status()
+
+    entry = _extract_entry(response.content)
+    if entry is None:
+        raise ValueError(f"No arXiv entry found for identifier '{arxiv_id}'")
+
+    title = _get_text(entry, "title")
+    summary = _get_text(entry, "summary")
+    authors = _extract_authors(entry)
+    published = _parse_date(_get_text(entry, "published"))
+    updated = _parse_date(_get_text(entry, "updated"))
+    pdf_url = _extract_pdf_url(entry) or f"https://arxiv.org/pdf/{arxiv_id}.pdf"
+    abs_url = f"https://arxiv.org/abs/{arxiv_id}"
+    doi = _get_text(entry, f"{_ARXIV_NS}doi")
+    primary_category = _get_attribute(entry, f"{_ARXIV_NS}primary_category", "term")
+    categories = sorted({term for term in _extract_categories(entry) if term})
+
+    workdir = Path(tempfile.mkdtemp(prefix="arxiv_"))
+    filename = f"{arxiv_id.replace('/', '_')}.pdf"
+    pdf_path = workdir / filename
+
+    logger.info("Downloading arXiv PDF from %s", pdf_url)
+    with session.get(pdf_url, headers=headers, stream=True, timeout=60) as pdf_response:
+        pdf_response.raise_for_status()
+        with pdf_path.open("wb") as buffer:
+            for chunk in pdf_response.iter_content(chunk_size=65536):
+                if chunk:
+                    buffer.write(chunk)
+
+    paper = ArxivPaper(
+        arxiv_id=arxiv_id,
+        title=title,
+        summary=summary,
+        authors=authors,
+        pdf_path=pdf_path,
+        pdf_url=pdf_url,
+        abs_url=abs_url,
+        published=published,
+        updated=updated,
+        categories=categories,
+        primary_category=primary_category,
+        doi=doi or None,
+        workdir=workdir,
+    )
+    return paper
+
+
+def _extract_entry(feed: bytes) -> Optional[ElementTree.Element]:
+    try:
+        tree = ElementTree.fromstring(feed)
+    except ElementTree.ParseError as exc:  # pragma: no cover - defensive logging
+        raise ValueError("Failed to parse arXiv metadata feed") from exc
+    return tree.find(f"{_ATOM_NS}entry")
+
+
+def _get_text(element: ElementTree.Element, name: str) -> str:
+    node = element.find(f"{_ATOM_NS}{name}" if not name.startswith("{") else name)
+    if node is not None and node.text:
+        return node.text.strip()
+    return ""
+
+
+def _extract_authors(entry: ElementTree.Element) -> list[str]:
+    names: list[str] = []
+    for author in entry.findall(f"{_ATOM_NS}author"):
+        name_node = author.find(f"{_ATOM_NS}name")
+        if name_node is not None and name_node.text:
+            names.append(name_node.text.strip())
+    return names
+
+
+def _extract_categories(entry: ElementTree.Element) -> Iterable[str]:
+    for category in entry.findall(f"{_ATOM_NS}category"):
+        term = category.get("term")
+        if term:
+            yield term
+
+
+def _extract_pdf_url(entry: ElementTree.Element) -> Optional[str]:
+    for link in entry.findall(f"{_ATOM_NS}link"):
+        if link.get("type") == "application/pdf":
+            href = link.get("href")
+            if href:
+                return href
+    return None
+
+
+def _get_attribute(entry: ElementTree.Element, tag: str, attribute: str) -> Optional[str]:
+    node = entry.find(tag)
+    if node is not None:
+        return node.get(attribute)
+    return None
+
+
+def _parse_date(value: str) -> Optional[datetime]:
+    if not value:
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    candidate = candidate.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(candidate)
+    except ValueError:
+        return None

--- a/worker/tigerchain_app/ingestion/pipeline.py
+++ b/worker/tigerchain_app/ingestion/pipeline.py
@@ -16,6 +16,7 @@ from ..utils.importance import DocumentImportanceScorer
 from ..utils.logging import get_logger
 from ..utils.subjects import SubjectClassifier
 from ..utils.text import resolve_document_id
+from .arxiv import fetch_arxiv_paper
 from .chunking import AdaptiveChunker
 from .loaders import SUPPORTED_EXTENSIONS, load_documents
 
@@ -307,6 +308,53 @@ class DocumentIngestionPipeline:
         self._persist_private_embeddings(private_embedding_cache, doc_id_map, submission_id, summaries, scope)
         logger.info("Persisted %s chunks to TigerGraph", len(rows))
         return IngestionResult(chunks=rows, documents=list(summaries.values()))
+
+    def ingest_arxiv(
+        self,
+        identifier: str,
+        *,
+        owner_id: str | None = None,
+        categories: Iterable[str] | None = None,
+        model_alias: str | None = None,
+        extra_metadata: dict | None = None,
+        embedding_scope: str | EmbeddingScope = "both",
+        submission_id: str | None = None,
+    ) -> IngestionResult:
+        scope = self._normalise_embedding_scope(embedding_scope)
+        paper = fetch_arxiv_paper(identifier)
+        logger.info("Ingesting arXiv paper %s", paper.arxiv_id)
+        category_values = {c.strip() for c in categories or [] if c and c.strip()}
+        category_values.update(paper.categories)
+        if paper.primary_category:
+            category_values.add(paper.primary_category)
+
+        metadata_block = paper.to_ingestion_metadata()
+        combined_metadata: dict[str, object]
+        if extra_metadata:
+            combined_metadata = dict(extra_metadata)
+            if isinstance(combined_metadata.get("arxiv"), dict):
+                merged = dict(metadata_block)
+                merged.update(combined_metadata["arxiv"])  # type: ignore[arg-type]
+                combined_metadata["arxiv"] = merged
+            else:
+                combined_metadata["arxiv"] = metadata_block
+        else:
+            combined_metadata = {"arxiv": metadata_block}
+        combined_metadata.setdefault("source", "arxiv")
+
+        try:
+            result = self.ingest_files(
+                [paper.pdf_path],
+                owner_id=owner_id,
+                categories=category_values,
+                model_alias=model_alias,
+                extra_metadata=combined_metadata,
+                embedding_scope=scope,
+                submission_id=submission_id or paper.arxiv_id.replace("/", "_"),
+            )
+        finally:
+            paper.cleanup()
+        return result
 
     # ------------------------------------------------------------------
     # Helpers


### PR DESCRIPTION
## Summary
- add an arXiv downloader that normalises identifiers, fetches metadata/PDFs, and feeds the ingestion pipeline with enriched metadata
- expose CLI and REST entry points for arXiv ingestion while reusing shared agent/category bookkeeping logic
- document the new workflow and add tests covering identifier parsing, metadata extraction, and pipeline integration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3d262e200832581e735c719f33e4f